### PR TITLE
feat: Security Context에서 로그인한 회원의 ID 정보 조회 구현, Swagger Authorization 헤더 추가

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/common/utils/LoginMember.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/utils/LoginMember.java
@@ -1,0 +1,12 @@
+package org.ioteatime.meonghanyangserver.common.utils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "id == null ? 0L : id")
+public @interface LoginMember {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/config/OpenApiConfig.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/config/OpenApiConfig.java
@@ -3,6 +3,13 @@ package org.ioteatime.meonghanyangserver.config;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
@@ -13,4 +20,48 @@ import org.springframework.context.annotation.Configuration;
                         version = "v1",
                         contact = @Contact(name = "서유진", email = "seoyoujin97@gmail.com")))
 @Configuration
-public class OpenApiConfig {}
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme apiKey =
+                new SecurityScheme()
+                        .type(SecurityScheme.Type.APIKEY)
+                        .in(SecurityScheme.In.HEADER)
+                        .name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("Bearer Token");
+
+        Server productionServer = new Server();
+        productionServer.setDescription("Production Server");
+        productionServer.setUrl("https://my-server-name.com");
+
+        Server localServer = new Server();
+        localServer.setDescription("Local Server");
+        localServer.setUrl("http://localhost:8080");
+
+        return new OpenAPI()
+                .addSecurityItem(getSecurityRequirement())
+                .components(getAuthComponent())
+                .servers(List.of(productionServer, localServer))
+                .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+                .addSecurityItem(securityRequirement);
+    }
+
+    private SecurityRequirement getSecurityRequirement() {
+        String jwt = "JWT";
+        return new SecurityRequirement().addList(jwt);
+    }
+
+    private Components getAuthComponent() {
+        return new Components()
+                .addSecuritySchemes(
+                        "JWT",
+                        new SecurityScheme()
+                                .name("JWT")
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization"));
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/user/controller/UserApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/user/controller/UserApi.java
@@ -4,9 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.ioteatime.meonghanyangserver.common.api.Api;
+import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
 import org.ioteatime.meonghanyangserver.user.dto.request.ChangePasswordRequest;
 import org.ioteatime.meonghanyangserver.user.dto.response.UserDetailResponse;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -17,9 +17,9 @@ public interface UserApi {
     Api<UserDetailResponse> getUserDetail(@PathVariable("userId") Long userId);
 
     @Operation(summary = "회원 정보를 삭제합니다.")
-    Api<Object> deleteUser(@PathVariable("userId") Long userId);
+    Api<Object> deleteUser(@LoginMember Long userId);
 
     @Operation(summary = "회원의 비밀번호를 변경합니다.")
     Api<Object> changeUserPassword(
-            Authentication authentication, @RequestBody @Valid ChangePasswordRequest request);
+            @LoginMember Long userId, @RequestBody @Valid ChangePasswordRequest request);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/user/controller/UserController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/user/controller/UserController.java
@@ -3,10 +3,10 @@ package org.ioteatime.meonghanyangserver.user.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.common.api.Api;
+import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
 import org.ioteatime.meonghanyangserver.user.dto.request.ChangePasswordRequest;
 import org.ioteatime.meonghanyangserver.user.dto.response.UserDetailResponse;
 import org.ioteatime.meonghanyangserver.user.service.UserService;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,23 +16,21 @@ public class UserController implements UserApi {
     private final UserService userService;
 
     @GetMapping("/{userId}")
-    public Api<UserDetailResponse> getUserDetail(Long userId) {
+    public Api<UserDetailResponse> getUserDetail(@PathVariable("userId") Long userId) {
         UserDetailResponse userDto = userService.getUserDetail(userId);
         return Api.OK(userDto);
     }
 
-    @DeleteMapping("/{userId}")
-    public Api<Object> deleteUser(Long userId) {
+    @DeleteMapping
+    public Api<Object> deleteUser(@LoginMember Long userId) {
         userService.deleteUser(userId);
         return Api.OK();
     }
 
     @PutMapping("/password")
     public Api<Object> changeUserPassword(
-            Authentication authentication, @RequestBody @Valid ChangePasswordRequest request) {
-
-        userService.changeUserPassword(authentication, request);
-
+            @LoginMember Long userId, @RequestBody @Valid ChangePasswordRequest request) {
+        userService.changeUserPassword(userId, request);
         return Api.OK();
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/user/dto/CustomUserDetail.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/user/dto/CustomUserDetail.java
@@ -32,4 +32,8 @@ public class CustomUserDetail implements UserDetails {
     public String getUsername() {
         return userEntity.getEmail();
     }
+
+    public Long getId() {
+        return userEntity.getId();
+    }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/user/service/UserService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/user/service/UserService.java
@@ -4,11 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.common.error.ErrorTypeCode;
 import org.ioteatime.meonghanyangserver.common.exception.ApiException;
 import org.ioteatime.meonghanyangserver.user.domain.UserEntity;
-import org.ioteatime.meonghanyangserver.user.dto.CustomUserDetail;
 import org.ioteatime.meonghanyangserver.user.dto.request.ChangePasswordRequest;
 import org.ioteatime.meonghanyangserver.user.dto.response.UserDetailResponse;
 import org.ioteatime.meonghanyangserver.user.repository.UserRepository;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,11 +32,9 @@ public class UserService {
     }
 
     @Transactional
-    public void changeUserPassword(Authentication authentication, ChangePasswordRequest request) {
+    public void changeUserPassword(Long userId, ChangePasswordRequest request) {
         String currentPassword = request.getCurrentPassword();
         String newPassword = request.getNewPassword();
-        CustomUserDetail userDetails = (CustomUserDetail) authentication.getPrincipal();
-        Long userId = userDetails.getUserEntity().getId();
 
         UserEntity userEntity =
                 userRepository


### PR DESCRIPTION
### 📋 상세 설명
- Security Context에서 요청을 보낸 로그인한 회원의 ID 정보 조회를 구현하였습니다.
- `@LoginMember` 애노테이션을 `Controller` 레이어에서 사용하시고, `Service` 레이어로 넘기시면 됩니다.
- Swagger Authorization 헤더를 추가했습니다.
- Swagger에서 Authorization 헤더를 기입하고 (앞에 Bearer 붙이기) 요청을 보낼 수 있습니다.

### 📸 스크린샷
`@LoginMember` 애노테이션 사용 방법은 코드 변경사항을 참고해 주세요

Swagger Authorization 헤더 사용 방법
<img width="1461" alt="Screenshot 2024-10-30 at 10 14 41" src="https://github.com/user-attachments/assets/3ab199fc-741d-42fb-a4b2-6fafcf228fc4">
<img width="1464" alt="Screenshot 2024-10-30 at 10 14 59" src="https://github.com/user-attachments/assets/bc784947-cae0-406a-a644-d2ceed4748f1">