### PR TITLE
refactor: Mapper 구현, 프로필 설정 분리 등

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/mapper/AuthEntityMapper.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/mapper/AuthEntityMapper.java
@@ -1,0 +1,14 @@
+package org.ioteatime.meonghanyangserver.auth.mapper;
+
+import org.ioteatime.meonghanyangserver.user.domain.UserEntity;
+import org.ioteatime.meonghanyangserver.user.dto.UserDto;
+
+public class AuthEntityMapper {
+    public static UserEntity of(UserDto userDto, String encodedPassword) {
+        return UserEntity.builder()
+                .nickname(userDto.getNickname())
+                .email(userDto.getEmail())
+                .password(encodedPassword)
+                .build();
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/mapper/AuthResponseMapper.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/mapper/AuthResponseMapper.java
@@ -1,0 +1,23 @@
+package org.ioteatime.meonghanyangserver.auth.mapper;
+
+import org.ioteatime.meonghanyangserver.auth.dto.reponse.LoginResponse;
+import org.ioteatime.meonghanyangserver.auth.dto.reponse.RefreshResponse;
+import org.ioteatime.meonghanyangserver.user.dto.response.UserSimpleResponse;
+
+public class AuthResponseMapper {
+    public static UserSimpleResponse from(Long id, String email) {
+        return new UserSimpleResponse(id, email);
+    }
+
+    public static LoginResponse from(Long id, String accessToken, String refreshToken) {
+        return LoginResponse.builder()
+                .userId(id)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public static RefreshResponse from(String newAccessToken) {
+        return new RefreshResponse(newAccessToken);
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/api/Api.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/api/Api.java
@@ -5,7 +5,7 @@ import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.ioteatime.meonghanyangserver.common.error.TypeCodeIfs;
+import org.ioteatime.meonghanyangserver.common.error.TypeCode;
 
 @Data
 @AllArgsConstructor
@@ -33,17 +33,17 @@ public class Api<T> {
     }
 
     // 정상 응답
-    public static <T> Api<T> OK(TypeCodeIfs typeCodeIfs, T data) {
+    public static <T> Api<T> OK(TypeCode typeCode, T data) {
         Api<T> api = new Api<T>();
-        api.result = Result.OK(typeCodeIfs);
+        api.result = Result.OK(typeCode);
         api.body = data;
         return api;
     }
 
     // 정상 응답
-    public static <T> Api<T> OK(TypeCodeIfs typeCodeIfs) {
+    public static <T> Api<T> OK(TypeCode typeCode) {
         Api<T> api = new Api<T>();
-        api.result = Result.OK(typeCodeIfs);
+        api.result = Result.OK(typeCode);
         return api;
     }
 
@@ -60,23 +60,23 @@ public class Api<T> {
         return api;
     }
 
-    public static Api<Object> CREATE(TypeCodeIfs typeCodeIfs) {
+    public static Api<Object> CREATE(TypeCode typeCode) {
         Api<Object> api = new Api<>();
-        api.result = Result.CREATE(typeCodeIfs);
+        api.result = Result.CREATE(typeCode);
         return api;
     }
 
-    public static <T> Api<T> CREATE(TypeCodeIfs typeCodeIfs, T data) {
+    public static <T> Api<T> CREATE(TypeCode typeCode, T data) {
         Api<T> api = new Api<T>();
-        api.result = Result.CREATE(typeCodeIfs);
+        api.result = Result.CREATE(typeCode);
         api.body = data;
         return api;
     }
 
     // 에러 응답
-    public static Api<Object> ERROR(TypeCodeIfs typeCodeIfs) {
+    public static Api<Object> ERROR(TypeCode typeCode) {
         Api<Object> api = new Api<Object>();
-        api.result = Result.ERROR(typeCodeIfs);
+        api.result = Result.ERROR(typeCode);
         return api;
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/api/Result.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/api/Result.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.ioteatime.meonghanyangserver.common.error.SuccessTypeCode;
-import org.ioteatime.meonghanyangserver.common.error.TypeCodeIfs;
+import org.ioteatime.meonghanyangserver.common.error.TypeCode;
 
 @Builder
 @Data
@@ -26,11 +26,11 @@ public class Result {
     }
 
     // 성공 응답 커스텀
-    public static Result OK(TypeCodeIfs typeCodeIfs) {
+    public static Result OK(TypeCode typeCode) {
         return Result.builder()
-                .code(typeCodeIfs.getCode())
-                .message(typeCodeIfs.getMessage())
-                .description(typeCodeIfs.getDescription())
+                .code(typeCode.getCode())
+                .message(typeCode.getMessage())
+                .description(typeCode.getDescription())
                 .build();
     }
 
@@ -43,19 +43,19 @@ public class Result {
                 .build();
     }
 
-    public static Result CREATE(TypeCodeIfs typeCodeIfs) {
+    public static Result CREATE(TypeCode typeCode) {
         return Result.builder()
-                .code(typeCodeIfs.getCode())
-                .message(typeCodeIfs.getMessage())
-                .description(typeCodeIfs.getDescription())
+                .code(typeCode.getCode())
+                .message(typeCode.getMessage())
+                .description(typeCode.getDescription())
                 .build();
     }
 
     // 에러 응답
-    public static Result ERROR(TypeCodeIfs typeCodeIfs) {
+    public static Result ERROR(TypeCode typeCode) {
         return Result.builder()
-                .code(typeCodeIfs.getCode())
-                .message(typeCodeIfs.getMessage())
+                .code(typeCode.getCode())
+                .message(typeCode.getMessage())
                 .description("ERROR")
                 .build();
     }

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/error/ErrorTypeCode.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/error/ErrorTypeCode.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public enum ErrorTypeCode implements TypeCodeIfs {
+public enum ErrorTypeCode implements TypeCode {
     // 잘못된 요청
     BAD_REQUEST(400, "bad request", "잘못된 요청"),
     // 서버 오류

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/error/SuccessTypeCode.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/error/SuccessTypeCode.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public enum SuccessTypeCode implements TypeCodeIfs {
+public enum SuccessTypeCode implements TypeCode {
     // 성공
     OK(200, "OK", "success"),
     // 생성

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/error/TypeCode.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/error/TypeCode.java
@@ -1,6 +1,6 @@
 package org.ioteatime.meonghanyangserver.common.error;
 
-public interface TypeCodeIfs {
+public interface TypeCode {
     Integer getCode();
 
     String getMessage();

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/exception/ApiException.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/exception/ApiException.java
@@ -1,22 +1,9 @@
 package org.ioteatime.meonghanyangserver.common.exception;
 
-import lombok.Getter;
-import org.ioteatime.meonghanyangserver.common.error.TypeCodeIfs;
+import org.ioteatime.meonghanyangserver.common.error.TypeCode;
 
-@Getter
-public class ApiException extends RuntimeException implements ApiExceptionItf {
-    private final TypeCodeIfs typeCodeIfs;
-    private final String errorDescription;
+public interface ApiException {
+    TypeCode getTypeCode();
 
-    public ApiException(TypeCodeIfs typeCodeIfs) {
-        super(typeCodeIfs.getDescription());
-        this.typeCodeIfs = typeCodeIfs;
-        this.errorDescription = typeCodeIfs.getDescription();
-    }
-
-    public ApiException(TypeCodeIfs typeCodeIfs, String errorDescription) {
-        super(errorDescription);
-        this.typeCodeIfs = typeCodeIfs;
-        this.errorDescription = errorDescription;
-    }
+    String getErrorDescription();
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/exception/ApiExceptionImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/exception/ApiExceptionImpl.java
@@ -1,0 +1,22 @@
+package org.ioteatime.meonghanyangserver.common.exception;
+
+import lombok.Getter;
+import org.ioteatime.meonghanyangserver.common.error.TypeCode;
+
+@Getter
+public class ApiExceptionImpl extends RuntimeException implements ApiException {
+    private final TypeCode typeCode;
+    private final String errorDescription;
+
+    public ApiExceptionImpl(TypeCode typeCode) {
+        super(typeCode.getDescription());
+        this.typeCode = typeCode;
+        this.errorDescription = typeCode.getDescription();
+    }
+
+    public ApiExceptionImpl(TypeCode typeCode, String errorDescription) {
+        super(errorDescription);
+        this.typeCode = typeCode;
+        this.errorDescription = errorDescription;
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/exception/ApiExceptionItf.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/exception/ApiExceptionItf.java
@@ -1,9 +1,0 @@
-package org.ioteatime.meonghanyangserver.common.exception;
-
-import org.ioteatime.meonghanyangserver.common.error.TypeCodeIfs;
-
-public interface ApiExceptionItf {
-    TypeCodeIfs getTypeCodeIfs();
-
-    String getErrorDescription();
-}

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/utils/JwtUtils.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/utils/JwtUtils.java
@@ -93,7 +93,7 @@ public class JwtUtils {
     }
 
     public String extractTokenFromHeader(String authorizationHeader) {
-        return authorizationHeader.replace("Bearer ", "");
+        return authorizationHeader.substring(7);
     }
 
     public Long getIdFromToken(String token) {

--- a/src/main/java/org/ioteatime/meonghanyangserver/filter/JwtRequestFilter.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/filter/JwtRequestFilter.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.ioteatime.meonghanyangserver.common.error.ErrorTypeCode;
-import org.ioteatime.meonghanyangserver.common.exception.ApiException;
+import org.ioteatime.meonghanyangserver.common.exception.ApiExceptionImpl;
 import org.ioteatime.meonghanyangserver.common.utils.JwtUtils;
 import org.ioteatime.meonghanyangserver.group.repository.groupuser.GroupUserRepository;
 import org.ioteatime.meonghanyangserver.user.domain.UserEntity;
@@ -53,13 +53,14 @@ public class JwtRequestFilter extends OncePerRequestFilter {
             log.debug("jwt : ", jwtToken);
         } else {
             log.error("Authorization 헤더 누락 또는 토큰 형식 오류");
-            throw new ApiException(ErrorTypeCode.UNAUTHORIZED, "Authorization 헤더 누락 또는 토큰 형식 오류");
+            throw new ApiExceptionImpl(
+                    ErrorTypeCode.UNAUTHORIZED, "Authorization 헤더 누락 또는 토큰 형식 오류");
         }
         if (jwtId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             UserEntity entity =
                     userRepository
                             .findById(jwtId)
-                            .orElseThrow(() -> new ApiException(ErrorTypeCode.BAD_REQUEST));
+                            .orElseThrow(() -> new ApiExceptionImpl(ErrorTypeCode.BAD_REQUEST));
 
             log.debug(entity.getEmail());
             if (jwtUtils.validateToken(jwtToken, entity)) {

--- a/src/main/java/org/ioteatime/meonghanyangserver/group/service/GroupService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/group/service/GroupService.java
@@ -2,7 +2,7 @@ package org.ioteatime.meonghanyangserver.group.service;
 
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.common.error.ErrorTypeCode;
-import org.ioteatime.meonghanyangserver.common.exception.ApiException;
+import org.ioteatime.meonghanyangserver.common.exception.ApiExceptionImpl;
 import org.ioteatime.meonghanyangserver.group.domain.GroupEntity;
 import org.ioteatime.meonghanyangserver.group.domain.enums.GroupUserRole;
 import org.ioteatime.meonghanyangserver.group.dto.response.CreateGroupResponse;
@@ -29,7 +29,7 @@ public class GroupService {
         boolean groupUserEntity = groupUserService.existsGroupUser(userEntity);
 
         if (groupUserEntity) {
-            throw new ApiException(ErrorTypeCode.BAD_REQUEST);
+            throw new ApiExceptionImpl(ErrorTypeCode.BAD_REQUEST);
         }
 
         String roomName = userEntity.getNickname() + " 그룹";

--- a/src/main/java/org/ioteatime/meonghanyangserver/handler/ApiExceptionHandler.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/handler/ApiExceptionHandler.java
@@ -2,8 +2,8 @@ package org.ioteatime.meonghanyangserver.handler;
 
 import lombok.extern.slf4j.Slf4j;
 import org.ioteatime.meonghanyangserver.common.api.Api;
-import org.ioteatime.meonghanyangserver.common.error.TypeCodeIfs;
-import org.ioteatime.meonghanyangserver.common.exception.ApiException;
+import org.ioteatime.meonghanyangserver.common.error.TypeCode;
+import org.ioteatime.meonghanyangserver.common.exception.ApiExceptionImpl;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -15,10 +15,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Order(value = Integer.MIN_VALUE)
 @RestControllerAdvice
 public class ApiExceptionHandler {
-    @ExceptionHandler(value = ApiException.class)
-    public ResponseEntity<Api<Object>> apiResponseEntity(ApiException apiException) {
-        log.debug("", apiException);
-        TypeCodeIfs typeCodeIfs = apiException.getTypeCodeIfs();
-        return ResponseEntity.status(typeCodeIfs.getCode()).body(Api.ERROR(typeCodeIfs));
+    @ExceptionHandler(value = ApiExceptionImpl.class)
+    public ResponseEntity<Api<Object>> apiResponseEntity(ApiExceptionImpl apiExceptionImpl) {
+        log.debug("", apiExceptionImpl);
+        TypeCode typeCode = apiExceptionImpl.getTypeCode();
+        return ResponseEntity.status(typeCode.getCode()).body(Api.ERROR(typeCode));
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/user/domain/UserEntity.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/user/domain/UserEntity.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.ioteatime.meonghanyangserver.common.error.ErrorTypeCode;
-import org.ioteatime.meonghanyangserver.common.exception.ApiException;
+import org.ioteatime.meonghanyangserver.common.exception.ApiExceptionImpl;
 
 @Getter
 @Entity
@@ -39,7 +39,7 @@ public class UserEntity {
 
     public void setPassword(String encodedPassword) {
         if (encodedPassword == null || encodedPassword.isBlank()) {
-            throw new ApiException(ErrorTypeCode.BAD_REQUEST, "Password is empty");
+            throw new ApiExceptionImpl(ErrorTypeCode.BAD_REQUEST, "Password is empty");
         }
         this.password = encodedPassword;
     }

--- a/src/main/java/org/ioteatime/meonghanyangserver/user/dto/response/UserSimpleResponse.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/user/dto/response/UserSimpleResponse.java
@@ -1,9 +1,3 @@
 package org.ioteatime.meonghanyangserver.user.dto.response;
 
-import org.ioteatime.meonghanyangserver.user.domain.UserEntity;
-
-public record UserSimpleResponse(Long id, String email) {
-    public static UserSimpleResponse from(UserEntity user) {
-        return new UserSimpleResponse(user.getId(), user.getEmail());
-    }
-}
+public record UserSimpleResponse(Long id, String email) {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/user/mapper/UserResponseMapper.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/user/mapper/UserResponseMapper.java
@@ -1,0 +1,11 @@
+package org.ioteatime.meonghanyangserver.user.mapper;
+
+import org.ioteatime.meonghanyangserver.user.domain.UserEntity;
+import org.ioteatime.meonghanyangserver.user.dto.response.UserDetailResponse;
+
+public class UserResponseMapper {
+    public static UserDetailResponse from(UserEntity user) {
+        return new UserDetailResponse(
+                user.getId(), user.getEmail(), user.getProfileImgUrl(), user.getNickname());
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/user/service/UserService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/user/service/UserService.java
@@ -6,6 +6,7 @@ import org.ioteatime.meonghanyangserver.common.exception.ApiException;
 import org.ioteatime.meonghanyangserver.user.domain.UserEntity;
 import org.ioteatime.meonghanyangserver.user.dto.request.ChangePasswordRequest;
 import org.ioteatime.meonghanyangserver.user.dto.response.UserDetailResponse;
+import org.ioteatime.meonghanyangserver.user.mapper.UserResponseMapper;
 import org.ioteatime.meonghanyangserver.user.repository.UserRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -24,7 +25,7 @@ public class UserService {
                         .findById(userId)
                         .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
-        return UserDetailResponse.from(userEntity);
+        return UserResponseMapper.from(userEntity);
     }
 
     public void deleteUser(Long userId) {

--- a/src/main/java/org/ioteatime/meonghanyangserver/user/service/UserService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/user/service/UserService.java
@@ -2,7 +2,7 @@ package org.ioteatime.meonghanyangserver.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.common.error.ErrorTypeCode;
-import org.ioteatime.meonghanyangserver.common.exception.ApiException;
+import org.ioteatime.meonghanyangserver.common.exception.ApiExceptionImpl;
 import org.ioteatime.meonghanyangserver.user.domain.UserEntity;
 import org.ioteatime.meonghanyangserver.user.dto.request.ChangePasswordRequest;
 import org.ioteatime.meonghanyangserver.user.dto.response.UserDetailResponse;
@@ -42,11 +42,11 @@ public class UserService {
                         .findById(userId)
                         .orElseThrow(
                                 () ->
-                                        new ApiException(
+                                        new ApiExceptionImpl(
                                                 ErrorTypeCode.BAD_REQUEST, "User not found"));
 
         if (!bCryptPasswordEncoder.matches(currentPassword, userEntity.getPassword())) {
-            throw new ApiException(ErrorTypeCode.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다.");
+            throw new ApiExceptionImpl(ErrorTypeCode.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다.");
         }
 
         // Dirty-Checking Password Change

--- a/src/main/resources/application-db.yaml
+++ b/src/main/resources/application-db.yaml
@@ -1,0 +1,22 @@
+spring:
+  config:
+    activate:
+      on-profile: db
+  datasource:
+    url: ${MARIA_URL}
+    username: ${MARIA_USERNAME}
+    password: ${MARIA_PASSWORD}
+    driver-class-name: org.mariadb.jdbc.Driver
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+#  flyway:
+#    enabled: true
+#    baseline-on-migrate: true
+#    locations: classpath:db/migration
+
+logging:
+  level:
+    org.springframework.orm.jpa: INFO

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,27 +1,18 @@
 spring:
-  datasource:
-    url: ${MARIA_URL}
-    username: ${MARIA_USERNAME}
-    password: ${MARIA_PASSWORD}
-    driverClassName: org.mariadb.jdbc.Driver
+  config:
+    activate:
+      on-profile: dev
+    import: optional:application-secret.properties
   jpa:
     show-sql: true
     properties:
-      dialect: org.hibernate.dialect.MariaDBDialect
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
     hibernate:
       ddl-auto: update
-      default_batch_fetch_size: 100
   servlet:
     multipart:
       location: C:\\multipart\\uploads\\
       max-file-size: 10MB
       max-request-size: 10MB
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-      password: ${REDIS_PASSWORD}
-
-token:
-  expiration-time: 86400000
-  secret: VisitBBCfortrustedreportingonthelatestworldandUSnewssp

--- a/src/main/resources/application-key.yaml
+++ b/src/main/resources/application-key.yaml
@@ -1,0 +1,9 @@
+# 외부 키와 관련된 설정
+
+token:
+  expiration-time: 86400000
+  secret: ${JWT_SECRET}
+
+google:
+  service-account: ${GCP_SERVICE_ACCOUNT}
+  official-gmail: ${OFFICIAL_GMAIL}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,18 +1,8 @@
 spring:
-  config:
-    import: optional:application-secret.properties
   application:
     name: meong-ha-nyang-server
   profiles:
     active: dev
-  jackson:
-    time-zone: Asia/Seoul
-  jpa:
-    properties:
-      hibernate:
-        jdbc:
-          time_zone: Asia/Seoul
-
-google:
-  service-account: ${GCP_SERVICE_ACCOUNT}
-  official-gmail: ${OFFICIAL_GMAIL}
+    group:
+      dev: db, key
+      prod: db, key


### PR DESCRIPTION
### 📋 상세 설명
- EntityMapper, ResponseMapper를 구현하였습니다. 용도는 다음과 같습니다.
- EntityMapper : Request -> Domain(Entity) 변환 시
- ResponseMapper : Domain(Entity) -> Response 변환 시
- 스프링 프로필 설정을 분리하였습니다. db, key 설정을 따로 만들어 관심사를 분리했습니다.