### PR TITLE
feat: Redis를 활용한 이메일 인증 코드 발송 구현

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/clients/google/GoogleMailClient.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/clients/google/GoogleMailClient.java
@@ -85,7 +85,7 @@ public class GoogleMailClient {
             email.addRecipient(
                     javax.mail.Message.RecipientType.TO, new InternetAddress(toEmailAddress));
             email.setSubject(subject);
-            email.setText(message);
+            email.setContent(message, "text/html;charset=utf-8");
 
             // Encode and wrap the MIME message into a gmail message
             ByteArrayOutputStream buffer = new ByteArrayOutputStream();

--- a/src/main/java/org/ioteatime/meonghanyangserver/config/RedisConfig.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package org.ioteatime.meonghanyangserver.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories(
+        enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+        redisConfiguration.setHostName(host);
+        redisConfiguration.setPort(6379);
+        redisConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisConfiguration);
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/redis/EmailCode.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/redis/EmailCode.java
@@ -1,0 +1,18 @@
+package org.ioteatime.meonghanyangserver.redis;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RedisHash(value = "emailCode", timeToLive = 60 * 3)
+public class EmailCode {
+    @Id private Long id;
+
+    @Indexed private String email;
+
+    private String code;
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/redis/EmailCodeRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/redis/EmailCodeRepository.java
@@ -1,0 +1,8 @@
+package org.ioteatime.meonghanyangserver.redis;
+
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+
+public interface EmailCodeRepository extends CrudRepository<EmailCode, String> {
+    Optional<EmailCode> findByEmail(String email);
+}


### PR DESCRIPTION
### 📋 상세 설명
- 이메일 인증 코드 발송을 구현하였습니다.
- 이메일 인증 코드는 0-9까지의 숫자 3개, A-Z까지의 대문자 3개로 랜덤하게 생성되며, 순서 또한 랜덤하게 배치됩니다.
- 발급된 인증 코드는 Redis에 3분 간 저장됩니다.
- Redis에 저장되는 내용은 email, code입니다. email 필드에 `@Indexed` 애노테이션을 추가하여 email을 기준으로 데이터를 조회할 수 있도록 구현하였습니다.
- 이메일 내용은 html 형식으로 전송이 되며, 스타일링 없이 단순하게 만들어 두었습니다.
- 또한 Redis에서 `@Id`에 해당하는 필드에만 TTL(timeToLive)이 적용되는 문제가 있었습니다.
- RedisConfig에서 `EnableKeyspaceEvents.ON_STARTUP` 설정을 추가하여 문제를 해결하였습니다.
- 해당 설정은 다른 Redis Entity에도 적용이 됩니다.

### 📸 스크린샷
<img width="843" alt="Screenshot 2024-10-31 at 12 16 24" src="https://github.com/user-attachments/assets/9a456725-b824-4647-902b-0843a8fc61e7">

<img width="492" alt="Screenshot 2024-10-31 at 12 09 42" src="https://github.com/user-attachments/assets/cc67a4c1-a064-4524-9c85-73f22a5ed81e">

<img width="333" alt="Screenshot 2024-10-31 at 12 09 50" src="https://github.com/user-attachments/assets/14be771e-90b3-4903-a85a-ce5cb582452f">

<img width="437" alt="Screenshot 2024-10-31 at 12 10 11" src="https://github.com/user-attachments/assets/c7bafb14-5722-4d36-8c72-70b73fb115aa">

---

**TTL 관련 문제**
기존 3분 경과 후
<img width="341" alt="Screenshot 2024-10-31 at 12 26 16" src="https://github.com/user-attachments/assets/4255e7e3-170a-495d-99b1-fabe17fd8d84">
변경 후 3분 경과 후 (phantom 키가 하나 더 생겼습니다.)
<img width="347" alt="Screenshot 2024-10-31 at 12 31 31" src="https://github.com/user-attachments/assets/9c5a2739-ba03-4926-ae24-68614c641476">

### 📚 자료
- [Random-대신-ThreadLocalRandom을-써야-하는-이유](https://velog.io/@sojukang/Random-대신-ThreadLocalRandom을-써야-하는-이유)
- [RedisHash 사용 시 @Indexed 필드 TTL(timeToLive) 적용 안되는 문제](https://wildeveloperetrain.tistory.com/273)