### PR TITLE
fix: 회원 가입 시 비밀번호 검증, Refresh Token 갱신 API 수정

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthApi.java
@@ -4,14 +4,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.ioteatime.meonghanyangserver.auth.dto.reponse.LoginResponse;
-import org.ioteatime.meonghanyangserver.auth.dto.reponse.RefreshResponse;
 import org.ioteatime.meonghanyangserver.auth.dto.request.EmailRequest;
 import org.ioteatime.meonghanyangserver.auth.dto.request.LoginRequest;
 import org.ioteatime.meonghanyangserver.auth.dto.request.VerifyEmailRequest;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.user.dto.request.JoinRequest;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "Auth Api", description = "인증 관련 API 목록입니다.")
 public interface AuthApi {
@@ -29,7 +27,4 @@ public interface AuthApi {
 
     @Operation(summary = "이메일 중복을 확인 합니다.")
     Api<?> duplicateEmail(@Valid @RequestBody EmailRequest email);
-
-    @Operation(summary = "토큰을 다시 생성합니다.")
-    Api<RefreshResponse> refreshToken(@RequestHeader("Authorization") String authorizationHeader);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthApi.java
@@ -10,7 +10,6 @@ import org.ioteatime.meonghanyangserver.auth.dto.request.LoginRequest;
 import org.ioteatime.meonghanyangserver.auth.dto.request.VerifyEmailRequest;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.user.dto.request.JoinRequest;
-import org.ioteatime.meonghanyangserver.user.dto.response.UserSimpleResponse;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
@@ -29,7 +28,7 @@ public interface AuthApi {
     Api<LoginResponse> login(@RequestBody @Valid LoginRequest loginRequest);
 
     @Operation(summary = "이메일 중복을 확인 합니다.")
-    Api<UserSimpleResponse> duplicateEmail(@Valid @RequestBody EmailRequest email);
+    Api<?> duplicateEmail(@Valid @RequestBody EmailRequest email);
 
     @Operation(summary = "토큰을 다시 생성합니다.")
     Api<RefreshResponse> refreshToken(@RequestHeader("Authorization") String authorizationHeader);

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthController.java
@@ -2,7 +2,6 @@ package org.ioteatime.meonghanyangserver.auth.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.auth.dto.reponse.LoginResponse;
-import org.ioteatime.meonghanyangserver.auth.dto.reponse.RefreshResponse;
 import org.ioteatime.meonghanyangserver.auth.dto.request.EmailRequest;
 import org.ioteatime.meonghanyangserver.auth.dto.request.LoginRequest;
 import org.ioteatime.meonghanyangserver.auth.dto.request.VerifyEmailRequest;
@@ -47,12 +46,5 @@ public class AuthController implements AuthApi {
     public Api<LoginResponse> login(LoginRequest loginRequest) {
         LoginResponse loginResponse = authService.login(loginRequest);
         return Api.success(AuthSuccessType.SIGN_IN, loginResponse);
-    }
-
-    @PostMapping("/refresh-token")
-    public Api<RefreshResponse> refreshToken(
-            @RequestHeader("Authorization") String authorizationHeader) {
-        RefreshResponse refreshResponse = authService.reissueAccessToken(authorizationHeader);
-        return Api.success(AuthSuccessType.REISSUE_ACCESS_TOKEN, refreshResponse);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthController.java
@@ -1,6 +1,5 @@
 package org.ioteatime.meonghanyangserver.auth.controller;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.auth.dto.reponse.LoginResponse;
 import org.ioteatime.meonghanyangserver.auth.dto.reponse.RefreshResponse;
@@ -11,7 +10,6 @@ import org.ioteatime.meonghanyangserver.auth.service.AuthService;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.type.AuthSuccessType;
 import org.ioteatime.meonghanyangserver.user.dto.request.JoinRequest;
-import org.ioteatime.meonghanyangserver.user.dto.response.UserSimpleResponse;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,13 +19,13 @@ public class AuthController implements AuthApi {
     private final AuthService authService;
 
     @PostMapping("/sign-up")
-    public Api<Object> registerUser(@Valid @RequestBody JoinRequest userDto) {
+    public Api<Object> registerUser(@RequestBody JoinRequest userDto) {
         authService.joinProcess(userDto);
         return Api.success(AuthSuccessType.SIGN_UP);
     }
 
     @PostMapping("/email-verification")
-    public Api<?> sendEmailCode(@Valid @RequestBody EmailRequest emailReq) {
+    public Api<?> sendEmailCode(@RequestBody EmailRequest emailReq) {
         authService.send(emailReq.email());
         return Api.success(AuthSuccessType.SEND_EMAIL_CODE);
     }
@@ -40,8 +38,8 @@ public class AuthController implements AuthApi {
 
     // Email 중복 확인
     @PostMapping("/check-email")
-    public Api<UserSimpleResponse> duplicateEmail(@Valid @RequestBody EmailRequest emailReq) {
-        UserSimpleResponse response = authService.verifyEmail(emailReq.email());
+    public Api<?> duplicateEmail(@RequestBody EmailRequest emailReq) {
+        authService.verifyEmail(emailReq.email());
         return Api.success(AuthSuccessType.EMAIL_VERIFIED);
     }
 

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/dto/reponse/RefreshResponse.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/dto/reponse/RefreshResponse.java
@@ -1,6 +1,9 @@
 package org.ioteatime.meonghanyangserver.auth.dto.reponse;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
 
-public record RefreshResponse(@NotNull String accessToken) {}
+@Schema(description = "갱신된 AccessToken 입니다.")
+public record RefreshResponse(
+        @NotNull @Schema(description = "갱신된 AccessToken", example = "Bearer wefewfwe...")
+                String accessToken) {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/service/AuthService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/service/AuthService.java
@@ -6,7 +6,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.auth.dto.reponse.LoginResponse;
-import org.ioteatime.meonghanyangserver.auth.dto.reponse.RefreshResponse;
 import org.ioteatime.meonghanyangserver.auth.dto.request.LoginRequest;
 import org.ioteatime.meonghanyangserver.auth.mapper.AuthEntityMapper;
 import org.ioteatime.meonghanyangserver.auth.mapper.AuthResponseMapper;
@@ -117,34 +116,5 @@ public class AuthService {
         if (!code.equals(emailCode.getCode())) {
             throw new UnauthorizedException(AuthErrorType.CODE_NOT_EQUALS);
         }
-    }
-
-    public RefreshResponse reissueAccessToken(String authorizationHeader) {
-        String refreshToken = jwtUtils.extractTokenFromHeader(authorizationHeader);
-
-        Long userId = jwtUtils.getIdFromToken(refreshToken);
-        UserEntity userEntity =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new NotFoundException(AuthErrorType.NOT_FOUND));
-
-        if (!jwtUtils.validateToken(refreshToken, userEntity)) {
-            throw new NotFoundException(AuthErrorType.REFRESH_TOKEN_INVALID);
-        }
-
-        RefreshToken storedToken =
-                refreshTokenRepository
-                        .findByRefreshToken(refreshToken)
-                        .orElseThrow(
-                                () -> new NotFoundException(AuthErrorType.REFRESH_TOKEN_INVALID));
-
-        if (!storedToken.getRefreshToken().equals(refreshToken)) {
-            throw new BadRequestException(AuthErrorType.TOKEN_NOT_EQUALS);
-        }
-
-        String newAccessToken = jwtUtils.generateAccessToken(userEntity);
-        newAccessToken = jwtUtils.includeBearer(newAccessToken);
-
-        return AuthResponseMapper.from(newAccessToken);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/service/AuthService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/service/AuthService.java
@@ -68,6 +68,7 @@ public class AuthService {
 
     public UserSimpleResponse joinProcess(JoinRequest userDto) {
         String encodedPassword = bCryptPasswordEncoder.encode(userDto.getPassword());
+        verifyEmail(userDto.getEmail());
         UserEntity user = userRepository.save(AuthEntityMapper.of(userDto, encodedPassword));
 
         return AuthResponseMapper.from(user.getId(), user.getEmail());
@@ -102,13 +103,10 @@ public class AuthService {
         return String.join("", authStr);
     }
 
-    public UserSimpleResponse verifyEmail(String email) {
-        UserEntity userEntity =
-                userRepository
-                        .findByEmail(email)
-                        .orElseThrow(() -> new NotFoundException(AuthErrorType.NOT_FOUND));
-
-        return AuthResponseMapper.from(userEntity.getId(), userEntity.getEmail());
+    public void verifyEmail(String email) {
+        if (userRepository.findByEmail(email).isPresent()) {
+            throw new BadRequestException(AuthErrorType.EMAIL_DUPLICATED);
+        }
     }
 
     public void verifyEmailCode(String email, String code) {

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthErrorType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthErrorType.java
@@ -8,7 +8,8 @@ public enum AuthErrorType implements ErrorTypeCode {
     TOKEN_NOT_EQUALS("BAD REQUEST", "토큰이 일치하지 않습니다."),
     HEADER_INVALID("UNAUTHORIZED", "AUTHORIZATION 헤더가 누락되었거나 토큰 형식에 오류가 있습니다."),
     PASSWORD_INVALID("BAD REQUEST", "비밀번호가 유효하지 않습니다."),
-    CODE_NOT_EQUALS("BAD REQUEST", "이메일 인증 코드가 일치하지 않습니다.");
+    CODE_NOT_EQUALS("BAD REQUEST", "이메일 인증 코드가 일치하지 않습니다."),
+    EMAIL_DUPLICATED("BAD REQUEST", "이메일이 중복되었습니다.");
 
     private final String message;
     private final String description;

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthErrorType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthErrorType.java
@@ -9,7 +9,8 @@ public enum AuthErrorType implements ErrorTypeCode {
     HEADER_INVALID("UNAUTHORIZED", "AUTHORIZATION 헤더가 누락되었거나 토큰 형식에 오류가 있습니다."),
     PASSWORD_INVALID("BAD REQUEST", "비밀번호가 유효하지 않습니다."),
     CODE_NOT_EQUALS("BAD REQUEST", "이메일 인증 코드가 일치하지 않습니다."),
-    EMAIL_DUPLICATED("BAD REQUEST", "이메일이 중복되었습니다.");
+    EMAIL_DUPLICATED("BAD REQUEST", "이메일이 중복되었습니다."),
+    REFRESH_TOKEN_NOT_FOUND("NOT FOUND", "REFRESH TOKEN을 찾을 수 없습니다.");
 
     private final String message;
     private final String description;

--- a/src/main/java/org/ioteatime/meonghanyangserver/user/controller/UserApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/user/controller/UserApi.java
@@ -3,12 +3,14 @@ package org.ioteatime.meonghanyangserver.user.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.ioteatime.meonghanyangserver.auth.dto.reponse.RefreshResponse;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
 import org.ioteatime.meonghanyangserver.user.dto.request.ChangePasswordRequest;
 import org.ioteatime.meonghanyangserver.user.dto.response.UserDetailResponse;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "User Api", description = "유저 관련 API 목록입니다.")
 public interface UserApi {
@@ -22,4 +24,7 @@ public interface UserApi {
     @Operation(summary = "회원의 비밀번호를 변경합니다.")
     Api<Object> changeUserPassword(
             @LoginMember Long userId, @RequestBody @Valid ChangePasswordRequest request);
+
+    @Operation(summary = "Access 토큰을 다시 생성합니다.")
+    Api<RefreshResponse> refreshToken(@RequestHeader("Authorization") String authorizationHeader);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/user/controller/UserController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/user/controller/UserController.java
@@ -2,6 +2,7 @@ package org.ioteatime.meonghanyangserver.user.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.ioteatime.meonghanyangserver.auth.dto.reponse.RefreshResponse;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.type.AuthSuccessType;
 import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
@@ -33,5 +34,12 @@ public class UserController implements UserApi {
             @LoginMember Long userId, @RequestBody @Valid ChangePasswordRequest request) {
         userService.changeUserPassword(userId, request);
         return Api.success(AuthSuccessType.UPDATE_PASSWORD);
+    }
+
+    @PostMapping("/refresh-token")
+    public Api<RefreshResponse> refreshToken(
+            @RequestHeader("Authorization") String authorizationHeader) {
+        RefreshResponse refreshResponse = userService.reissueAccessToken(authorizationHeader);
+        return Api.success(AuthSuccessType.REISSUE_ACCESS_TOKEN, refreshResponse);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/user/dto/request/JoinRequest.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/user/dto/request/JoinRequest.java
@@ -17,10 +17,12 @@ public class JoinRequest {
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
     @Schema(description = "사용자의 비밀번호", example = "testpassword")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다.")
     private String password;
 
     @NotBlank(message = "비밀번호를 확인해주세요.")
     @Schema(description = "비밀번호 확인", example = "testpassword")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다.")
     private String passwordConfirm;
 
     @NotBlank(message = "닉네임을 입력해주세요.")

--- a/src/main/java/org/ioteatime/meonghanyangserver/user/service/UserService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/user/service/UserService.java
@@ -1,9 +1,14 @@
 package org.ioteatime.meonghanyangserver.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.ioteatime.meonghanyangserver.auth.dto.reponse.RefreshResponse;
+import org.ioteatime.meonghanyangserver.auth.mapper.AuthResponseMapper;
 import org.ioteatime.meonghanyangserver.common.exception.BadRequestException;
 import org.ioteatime.meonghanyangserver.common.exception.NotFoundException;
 import org.ioteatime.meonghanyangserver.common.type.AuthErrorType;
+import org.ioteatime.meonghanyangserver.common.utils.JwtUtils;
+import org.ioteatime.meonghanyangserver.redis.RefreshToken;
+import org.ioteatime.meonghanyangserver.redis.RefreshTokenRepository;
 import org.ioteatime.meonghanyangserver.user.domain.UserEntity;
 import org.ioteatime.meonghanyangserver.user.dto.request.ChangePasswordRequest;
 import org.ioteatime.meonghanyangserver.user.dto.response.UserDetailResponse;
@@ -16,9 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class UserService {
-
+    private final JwtUtils jwtUtils;
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public UserDetailResponse getUserDetail(Long userId) {
         UserEntity userEntity =
@@ -49,5 +55,34 @@ public class UserService {
 
         // Dirty-Checking Password Change
         userEntity.setPassword(bCryptPasswordEncoder.encode(newPassword));
+    }
+
+    public RefreshResponse reissueAccessToken(String authorizationHeader) {
+        String refreshToken = jwtUtils.extractTokenFromHeader(authorizationHeader);
+
+        Long userId = jwtUtils.getIdFromToken(refreshToken);
+        UserEntity userEntity =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new NotFoundException(AuthErrorType.NOT_FOUND));
+
+        if (!jwtUtils.validateToken(refreshToken, userEntity)) {
+            throw new NotFoundException(AuthErrorType.REFRESH_TOKEN_INVALID);
+        }
+
+        RefreshToken storedToken =
+                refreshTokenRepository
+                        .findByRefreshToken(refreshToken)
+                        .orElseThrow(
+                                () -> new NotFoundException(AuthErrorType.REFRESH_TOKEN_NOT_FOUND));
+
+        if (!storedToken.getRefreshToken().equals(refreshToken)) {
+            throw new BadRequestException(AuthErrorType.TOKEN_NOT_EQUALS);
+        }
+
+        String newAccessToken = jwtUtils.generateAccessToken(userEntity);
+        newAccessToken = jwtUtils.includeBearer(newAccessToken);
+
+        return AuthResponseMapper.from(newAccessToken);
     }
 }


### PR DESCRIPTION
### 📋 상세 설명
- 회원 가입 시 비밀번호 검증을 위한 애노테이션을 추가하였습니다.
- 그 과정에서 회원 가입에 이메일 중복 검사 또한 추가하다가, 비즈니스로직의 오류를 발견하여 해결하였습니다.
- 회원 가입에 이메일 중복 검사를 진행하는 이유는 회원 가입 API만 요청을 했을 때 이메일이 중복되어도 가입에 성공하기 때문입니다.
- RefreshToken 갱신 API가 open-api에 속해 있었습니다.
- 하지만 RefreshToken 갱신의 경우 RefreshToken을 헤더에 담아 요청을 보내는 것이 맞기 때문에 `/api/user/refresh-token`으로 경로를 수정하였습니다.

### 📸 스크린샷
<img width="840" alt="Screenshot 2024-10-31 at 15 33 52" src="https://github.com/user-attachments/assets/71166515-fdc6-4109-8de0-64a02d092f37">
<img width="837" alt="Screenshot 2024-10-31 at 15 43 19" src="https://github.com/user-attachments/assets/d4bd49d1-b421-4250-bdaa-433bd7bbbc32">
<img width="843" alt="Screenshot 2024-10-31 at 15 55 07" src="https://github.com/user-attachments/assets/20ad34ba-eb57-453b-9b07-92595d1b6ec1">