### PR TITLE
feat: CCTV와 KVS 신호 채널 삭제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // KVS
+    implementation 'com.amazonaws:aws-java-sdk-kinesisvideo:1.12.777'
 }
 
 spotless {

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvApi.java
@@ -1,0 +1,13 @@
+package org.ioteatime.meonghanyangserver.cctv.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.ioteatime.meonghanyangserver.common.api.Api;
+import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "CCTV Api", description = "CCTV 관련 API 목록입니다.")
+public interface CctvApi {
+    @Operation(summary = "CCTV 삭제(퇴출)")
+    Api<?> delete(@LoginMember Long userId, @PathVariable Long cctvId);
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvController.java
@@ -1,0 +1,24 @@
+package org.ioteatime.meonghanyangserver.cctv.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.ioteatime.meonghanyangserver.cctv.service.CctvService;
+import org.ioteatime.meonghanyangserver.common.api.Api;
+import org.ioteatime.meonghanyangserver.common.type.CctvSuccessType;
+import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cctv")
+public class CctvController implements CctvApi {
+    private final CctvService cctvService;
+
+    @DeleteMapping("/{cctvId}")
+    public Api<?> delete(@LoginMember Long userId, @PathVariable("cctvId") Long cctvId) {
+        cctvService.deleteById(userId, cctvId);
+        return Api.success(CctvSuccessType.DELETE_CCTV);
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/domain/CctvEntity.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/domain/CctvEntity.java
@@ -1,11 +1,14 @@
 package org.ioteatime.meonghanyangserver.cctv.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.ioteatime.meonghanyangserver.device.doamin.DeviceEntity;
 
 @Data
 @Entity
+@NoArgsConstructor
 @Table(name = "cctv")
 public class CctvEntity {
     @Id
@@ -21,4 +24,12 @@ public class CctvEntity {
     @OneToOne
     @JoinColumn(name = "device_id")
     private DeviceEntity device;
+
+    @Builder
+    public CctvEntity(Long id, String cctvNickname, String kvsChannelName, DeviceEntity device) {
+        this.id = id;
+        this.cctvNickname = cctvNickname;
+        this.kvsChannelName = kvsChannelName;
+        this.device = device;
+    }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/dto/db/CctvWithDeviceId.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/dto/db/CctvWithDeviceId.java
@@ -1,0 +1,3 @@
+package org.ioteatime.meonghanyangserver.cctv.dto.db;
+
+public record CctvWithDeviceId(Long cctvId, String kvsChannelName, Long deviceId) {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/repository/CctvRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/repository/CctvRepository.java
@@ -1,5 +1,15 @@
 package org.ioteatime.meonghanyangserver.cctv.repository;
 
+import java.util.Optional;
+import org.ioteatime.meonghanyangserver.cctv.domain.CctvEntity;
+import org.ioteatime.meonghanyangserver.cctv.dto.db.CctvWithDeviceId;
+
 public interface CctvRepository {
     boolean existsByKvsChannelName(String kvsChannelName);
+
+    void deleteById(Long cctvId);
+
+    Optional<CctvWithDeviceId> findByIdWithDeviceId(Long cctvId);
+
+    CctvEntity save(CctvEntity cctv);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/repository/CctvRepositoryImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/repository/CctvRepositoryImpl.java
@@ -1,14 +1,49 @@
 package org.ioteatime.meonghanyangserver.cctv.repository;
 
+import static org.ioteatime.meonghanyangserver.cctv.domain.QCctvEntity.cctvEntity;
+import static org.ioteatime.meonghanyangserver.device.doamin.QDeviceEntity.deviceEntity;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.ioteatime.meonghanyangserver.cctv.domain.CctvEntity;
+import org.ioteatime.meonghanyangserver.cctv.dto.db.CctvWithDeviceId;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class CctvRepositoryImpl implements CctvRepository {
+    private final JPAQueryFactory jpaQueryFactory;
     private final JpaCctvRepository jpaCctvRepository;
 
     public boolean existsByKvsChannelName(String kvsChannelName) {
         return jpaCctvRepository.existsByKvsChannelName(kvsChannelName);
+    }
+
+    @Override
+    public void deleteById(Long cctvId) {
+        jpaCctvRepository.deleteById(cctvId);
+    }
+
+    @Override
+    public Optional<CctvWithDeviceId> findByIdWithDeviceId(Long cctvId) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .select(
+                                Projections.constructor(
+                                        CctvWithDeviceId.class,
+                                        cctvEntity.id.as("cctvId"),
+                                        cctvEntity.kvsChannelName.as("kvsChannelName"),
+                                        cctvEntity.device.id.as("deviceId")))
+                        .from(cctvEntity)
+                        .join(cctvEntity.device, deviceEntity)
+                        .where(cctvEntity.id.eq(cctvId))
+                        .fetchOne());
+    }
+
+    @Override
+    public CctvEntity save(CctvEntity cctv) {
+        return jpaCctvRepository.save(cctv);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/service/CctvService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/service/CctvService.java
@@ -1,11 +1,43 @@
 package org.ioteatime.meonghanyangserver.cctv.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.ioteatime.meonghanyangserver.cctv.dto.db.CctvWithDeviceId;
 import org.ioteatime.meonghanyangserver.cctv.repository.CctvRepository;
+import org.ioteatime.meonghanyangserver.clients.kvs.KvsClient;
+import org.ioteatime.meonghanyangserver.common.exception.BadRequestException;
+import org.ioteatime.meonghanyangserver.common.exception.NotFoundException;
+import org.ioteatime.meonghanyangserver.common.type.CctvErrorType;
+import org.ioteatime.meonghanyangserver.device.repository.DeviceRepository;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class CctvService {
+    private final KvsClient kvsClient;
     private final CctvRepository cctvRepository;
+    private final DeviceRepository deviceRepository;
+
+    @Transactional
+    public void deleteById(Long userId, Long cctvId) {
+        // Device 테이블에서 userId를 조회하여 role 을 확인
+        if (deviceRepository.isMasterUserId(userId)) {
+            // MASTER 이면 CCTV 삭제 가능
+            CctvWithDeviceId cctv =
+                    cctvRepository
+                            .findByIdWithDeviceId(cctvId)
+                            .orElseThrow(() -> new NotFoundException(CctvErrorType.NOT_FOUND));
+            // 1. KVS 시그널링 채널 삭제
+            kvsClient.deleteSignalingChannel(cctv.kvsChannelName());
+            // 2. CCTV 테이블에서 삭제
+            cctvRepository.deleteById(cctvId);
+            System.out.println("HWEHREWR");
+            // 3. Device 테이블에서 삭제
+            deviceRepository.deleteById(cctv.deviceId());
+        } else {
+            // PARTICIPANT 이면 CCTV 삭제 실패
+            throw new BadRequestException(CctvErrorType.ONLY_MASTER_CAN_DELETE);
+        }
+        // CCTV 인 경우는 현재 MASTER 인 경우와 동일하므로 처리하지 않음
+    }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/service/CctvService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/service/CctvService.java
@@ -34,7 +34,6 @@ public class CctvService {
         kvsClient.deleteSignalingChannel(cctv.kvsChannelName());
         // 2. CCTV 테이블에서 삭제
         cctvRepository.deleteById(cctvId);
-        System.out.println("HWEHREWR");
         // 3. Device 테이블에서 삭제
         deviceRepository.deleteById(cctv.deviceId());
     }

--- a/src/main/java/org/ioteatime/meonghanyangserver/clients/kvs/KvsClient.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/clients/kvs/KvsClient.java
@@ -4,7 +4,10 @@ import com.amazonaws.services.kinesisvideo.AmazonKinesisVideo;
 import com.amazonaws.services.kinesisvideo.model.DeleteSignalingChannelRequest;
 import com.amazonaws.services.kinesisvideo.model.DescribeSignalingChannelRequest;
 import com.amazonaws.services.kinesisvideo.model.DescribeSignalingChannelResult;
+import com.amazonaws.services.kinesisvideo.model.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.ioteatime.meonghanyangserver.common.exception.NotFoundException;
+import org.ioteatime.meonghanyangserver.common.type.AwsErrorType;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,12 +20,18 @@ public class KvsClient {
                 new DescribeSignalingChannelRequest();
         signalingChannelRequest.setChannelName(channelName);
 
-        DescribeSignalingChannelResult signalingChannelResult =
-                amazonKinesisVideo.describeSignalingChannel(signalingChannelRequest);
+        try {
+            DescribeSignalingChannelResult signalingChannelResult =
+                    amazonKinesisVideo.describeSignalingChannel(signalingChannelRequest);
 
-        DeleteSignalingChannelRequest deleteChannelRequest = new DeleteSignalingChannelRequest();
-        deleteChannelRequest.setChannelARN(signalingChannelResult.getChannelInfo().getChannelARN());
+            DeleteSignalingChannelRequest deleteChannelRequest =
+                    new DeleteSignalingChannelRequest();
+            deleteChannelRequest.setChannelARN(
+                    signalingChannelResult.getChannelInfo().getChannelARN());
 
-        amazonKinesisVideo.deleteSignalingChannel(deleteChannelRequest);
+            amazonKinesisVideo.deleteSignalingChannel(deleteChannelRequest);
+        } catch (ResourceNotFoundException err) {
+            throw new NotFoundException(AwsErrorType.KVS_CHANNEL_NAME_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/clients/kvs/KvsClient.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/clients/kvs/KvsClient.java
@@ -1,0 +1,28 @@
+package org.ioteatime.meonghanyangserver.clients.kvs;
+
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideo;
+import com.amazonaws.services.kinesisvideo.model.DeleteSignalingChannelRequest;
+import com.amazonaws.services.kinesisvideo.model.DescribeSignalingChannelRequest;
+import com.amazonaws.services.kinesisvideo.model.DescribeSignalingChannelResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KvsClient {
+    private final AmazonKinesisVideo amazonKinesisVideo;
+
+    public void deleteSignalingChannel(String channelName) {
+        DescribeSignalingChannelRequest signalingChannelRequest =
+                new DescribeSignalingChannelRequest();
+        signalingChannelRequest.setChannelName(channelName);
+
+        DescribeSignalingChannelResult signalingChannelResult =
+                amazonKinesisVideo.describeSignalingChannel(signalingChannelRequest);
+
+        DeleteSignalingChannelRequest deleteChannelRequest = new DeleteSignalingChannelRequest();
+        deleteChannelRequest.setChannelARN(signalingChannelResult.getChannelInfo().getChannelARN());
+
+        amazonKinesisVideo.deleteSignalingChannel(deleteChannelRequest);
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/AwsErrorType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/AwsErrorType.java
@@ -1,0 +1,23 @@
+package org.ioteatime.meonghanyangserver.common.type;
+
+public enum AwsErrorType implements ErrorTypeCode {
+    KVS_CHANNEL_NAME_NOT_FOUND("NOT FOUND", "채널 이름에 해당하는 KVS 채널을 찾을 수 없습니다.");
+
+    private final String message;
+    private final String description;
+
+    AwsErrorType(String message, String description) {
+        this.message = message;
+        this.description = description;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/CctvErrorType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/CctvErrorType.java
@@ -1,0 +1,24 @@
+package org.ioteatime.meonghanyangserver.common.type;
+
+public enum CctvErrorType implements ErrorTypeCode {
+    ONLY_MASTER_CAN_DELETE("BAD REQUEST", "CCTV는 MASTER만 삭제할 수 있습니다."),
+    NOT_FOUND("NOT FOUND", "CCTV를 찾을 수 없습니다.");
+
+    private final String message;
+    private final String description;
+
+    CctvErrorType(String message, String description) {
+        this.message = message;
+        this.description = description;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/CctvSuccessType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/CctvSuccessType.java
@@ -1,0 +1,30 @@
+package org.ioteatime.meonghanyangserver.common.type;
+
+public enum CctvSuccessType implements SuccessTypeCode {
+    DELETE_CCTV(200, "OK", "CCTV 삭제(퇴출)에 성공하였습니다.");
+
+    private final Integer code;
+    private final String message;
+    private final String description;
+
+    CctvSuccessType(Integer code, String message, String description) {
+        this.code = code;
+        this.message = message;
+        this.description = description;
+    }
+
+    @Override
+    public Integer getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/config/AwsConfig.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/config/AwsConfig.java
@@ -1,0 +1,38 @@
+package org.ioteatime.meonghanyangserver.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideo;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsConfig {
+    @Value("${aws.kvs.access-key}")
+    private String kvsAccessKey;
+
+    @Value("${aws.kvs.secret-key}")
+    private String kvsSecretKey;
+
+    @Bean
+    public AmazonKinesisVideo amazonKinesisVideo() {
+        AWSCredentials awsCredentials =
+                new AWSCredentials() {
+                    @Override
+                    public String getAWSAccessKeyId() {
+                        return kvsAccessKey;
+                    }
+
+                    @Override
+                    public String getAWSSecretKey() {
+                        return kvsSecretKey;
+                    }
+                };
+
+        return AmazonKinesisVideoClient.builder()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/device/doamin/DeviceEntity.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/device/doamin/DeviceEntity.java
@@ -33,7 +33,7 @@ public class DeviceEntity {
     private GroupEntity group;
 
     @ManyToOne
-    @JoinColumn(name = "user_id", unique = true)
+    @JoinColumn(name = "user_id")
     private UserEntity user;
 
     @OneToOne(mappedBy = "device")

--- a/src/main/java/org/ioteatime/meonghanyangserver/device/repository/DeviceRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/device/repository/DeviceRepository.java
@@ -12,4 +12,10 @@ public interface DeviceRepository {
     Optional<DeviceEntity> findByDeviceId(Long userId);
 
     GroupEntity findDevice(Long userId);
+
+    boolean isMasterUserId(Long userId);
+
+    void deleteById(Long id);
+
+    DeviceEntity save(DeviceEntity device);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/device/repository/DeviceRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/device/repository/DeviceRepository.java
@@ -13,7 +13,7 @@ public interface DeviceRepository {
 
     GroupEntity findDevice(Long userId);
 
-    boolean isMasterUserId(Long userId);
+    boolean isParcitipantUserId(Long userId);
 
     void deleteById(Long id);
 

--- a/src/main/java/org/ioteatime/meonghanyangserver/device/repository/DeviceRepositoryImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/device/repository/DeviceRepositoryImpl.java
@@ -42,8 +42,8 @@ public class DeviceRepositoryImpl implements DeviceRepository {
     }
 
     @Override
-    public boolean isMasterUserId(Long userId) {
-        return !jpaQueryFactory
+    public boolean isParcitipantUserId(Long userId) {
+        return jpaQueryFactory
                 .select(deviceEntity.role)
                 .from(deviceEntity)
                 .where(
@@ -51,7 +51,7 @@ public class DeviceRepositoryImpl implements DeviceRepository {
                                 .user
                                 .id
                                 .eq(userId)
-                                .and(deviceEntity.role.eq(DeviceRole.ROLE_MASTER)))
+                                .and(deviceEntity.role.eq(DeviceRole.ROLE_PARTICIPANT)))
                 .fetch()
                 .isEmpty();
     }

--- a/src/main/java/org/ioteatime/meonghanyangserver/device/repository/DeviceRepositoryImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/device/repository/DeviceRepositoryImpl.java
@@ -43,7 +43,7 @@ public class DeviceRepositoryImpl implements DeviceRepository {
 
     @Override
     public boolean isParcitipantUserId(Long userId) {
-        return jpaQueryFactory
+        return !jpaQueryFactory
                 .select(deviceEntity.role)
                 .from(deviceEntity)
                 .where(

--- a/src/main/java/org/ioteatime/meonghanyangserver/device/repository/DeviceRepositoryImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/device/repository/DeviceRepositoryImpl.java
@@ -1,10 +1,12 @@
 package org.ioteatime.meonghanyangserver.device.repository;
 
+import static org.ioteatime.meonghanyangserver.device.doamin.QDeviceEntity.deviceEntity;
+
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.device.doamin.DeviceEntity;
-import org.ioteatime.meonghanyangserver.device.doamin.QDeviceEntity;
+import org.ioteatime.meonghanyangserver.device.doamin.enums.DeviceRole;
 import org.ioteatime.meonghanyangserver.group.domain.GroupEntity;
 import org.springframework.stereotype.Repository;
 
@@ -32,12 +34,35 @@ public class DeviceRepositoryImpl implements DeviceRepository {
 
     @Override
     public GroupEntity findDevice(Long userId) {
-        QDeviceEntity groupUserEntity = QDeviceEntity.deviceEntity;
-
         return jpaQueryFactory
-                .select(groupUserEntity.group)
-                .where(groupUserEntity.user.id.eq(userId))
-                .from(groupUserEntity)
+                .select(deviceEntity.group)
+                .from(deviceEntity)
+                .where(deviceEntity.user.id.eq(userId))
                 .fetchOne();
+    }
+
+    @Override
+    public boolean isMasterUserId(Long userId) {
+        return !jpaQueryFactory
+                .select(deviceEntity.role)
+                .from(deviceEntity)
+                .where(
+                        deviceEntity
+                                .user
+                                .id
+                                .eq(userId)
+                                .and(deviceEntity.role.eq(DeviceRole.ROLE_MASTER)))
+                .fetch()
+                .isEmpty();
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        jpaDeviceRepository.deleteById(id);
+    }
+
+    @Override
+    public DeviceEntity save(DeviceEntity device) {
+        return jpaDeviceRepository.save(device);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/group/domain/GroupEntity.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/group/domain/GroupEntity.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.ioteatime.meonghanyangserver.device.doamin.DeviceEntity;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Data
 @Entity
@@ -15,6 +17,7 @@ import org.ioteatime.meonghanyangserver.device.doamin.DeviceEntity;
 @AllArgsConstructor
 @Builder
 @Table(name = "`group`")
+@EntityListeners(AuditingEntityListener.class)
 public class GroupEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,8 +26,7 @@ public class GroupEntity {
     @Column(nullable = false, length = 100)
     private String groupName;
 
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
+    @Column @CreatedDate private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "group")
     private List<DeviceEntity> deviceEntities;

--- a/src/main/java/org/ioteatime/meonghanyangserver/group/repository/GroupRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/group/repository/GroupRepository.java
@@ -3,5 +3,5 @@ package org.ioteatime.meonghanyangserver.group.repository;
 import org.ioteatime.meonghanyangserver.group.domain.GroupEntity;
 
 public interface GroupRepository {
-    GroupEntity createGroup(GroupEntity groupEntity);
+    GroupEntity save(GroupEntity groupEntity);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/group/repository/GroupRepositoryImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/group/repository/GroupRepositoryImpl.java
@@ -10,7 +10,7 @@ public class GroupRepositoryImpl implements GroupRepository {
     private final JpaGroupRepository jpaGroupRepository;
 
     @Override
-    public GroupEntity createGroup(GroupEntity groupEntity) {
+    public GroupEntity save(GroupEntity groupEntity) {
         return jpaGroupRepository.save(groupEntity);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/group/service/GroupService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/group/service/GroupService.java
@@ -46,7 +46,7 @@ public class GroupService {
 
         GroupEntity groupEntity = GroupEntityMapper.toEntity(roomName);
 
-        GroupEntity newGroupEntity = groupRepository.createGroup(groupEntity);
+        GroupEntity newGroupEntity = groupRepository.save(groupEntity);
 
         deviceService.createDevice(
                 newGroupEntity,

--- a/src/main/resources/application-key.yaml
+++ b/src/main/resources/application-key.yaml
@@ -7,3 +7,8 @@ token:
 google:
   service-account: ${GCP_SERVICE_ACCOUNT}
   official-gmail: ${OFFICIAL_GMAIL}
+
+aws:
+  kvs:
+    access-key: ${AWS_KVS_ACCESS_KEY}
+    secret-key: ${AWS_KVS_SECRET_KEY}


### PR DESCRIPTION
### 📋 상세 설명
- CCTV를 삭제(퇴출)하는 기능을 구현하였습니다.
- MASTER, CCTV role을 가진 회원만 CCTV를 삭제할 수 있습니다. (퇴출하거나, 스스로 나가거나)
- 삭제할 CCTV의 ID는 프론트에서 넘겨 받습니다.
- 삭제 순서는 다음과 같습니다.
  1. KVS 신호 채널을 삭제
  2. CCTV 테이블에서 ID에 해당하는 데이터 삭제
  3. Device 테이블에서 CCTV가 가지고 있던 deviceId에 해당하는 데이터 삭제
- AwsConfig에서 키를 가지고 자격 증명을 얻습니다.
- KvsClient에서 자격 증명을 활용하여 KVS 관련 로직을 처리합니다.
- JavaSDK를 활용하여 KVS 신호 채널을 삭제합니다. 이때 신호채널의 이름이 존재하지 않는다면 오류를 응답합니다.
- CCTV 정보를 조회할 때 꼭 필요한 정보만 querydsl로 조회할 수 있도록 최적화 하였습니다.
- <mark>그런데 group과 device가 순환참조가 되고 있는 것 같아서, 이 부분 괜찮을지 확인해 보시면 좋을 것 같습니다. (양방향 매핑의 문제점이긴 한데 .. 고민해볼 만한 주제인 것 같아요!)</mark>

### 📸 스크린샷
**초기 데이터**
<img width="310" alt="Screenshot 2024-11-01 at 20 57 37" src="https://github.com/user-attachments/assets/e11718c4-d1ba-452a-962c-26653e14d6f7">
<img width="295" alt="Screenshot 2024-11-01 at 20 58 05" src="https://github.com/user-attachments/assets/b92dbbd6-1a9f-4dd6-8d6b-cbbda880440a">
<img width="866" alt="Screenshot 2024-11-01 at 20 58 34" src="https://github.com/user-attachments/assets/eee9e31f-bc6b-4dab-ad3b-613602ebb7de">

**삭제 요청 성공**
<img width="841" alt="Screenshot 2024-11-01 at 21 00 38" src="https://github.com/user-attachments/assets/97908760-a1d1-4401-abef-8f8b1e9383ba">

**권한 실패**
<img width="836" alt="Screenshot 2024-11-01 at 21 14 18" src="https://github.com/user-attachments/assets/be456341-5978-406e-bf4b-300d92a3fb1d">

**KVS 신호 채널 이름 없을 때**
<img width="839" alt="Screenshot 2024-11-01 at 21 41 26" src="https://github.com/user-attachments/assets/35df5a26-8397-4fb0-beb0-66b7fb8e6d43">

### 📚 자료
- [JavaSDK](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/kinesisvideo/AmazonKinesisVideoClient.html#builder--)
- [JavaSDK Maven](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-kinesisvideo/1.12.777)
- [AWS Credentials 설정](https://javabom.tistory.com/95)