### PR TITLE
refactor: 도메인 변경으로 인한 CCTV 퇴출 코드 수정

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvApi.java
@@ -8,6 +8,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "CCTV Api", description = "CCTV 관련 API 목록입니다.")
 public interface CctvApi {
-    @Operation(summary = "CCTV 삭제(퇴출)", description = "담당자: 양원채")
-    Api<?> delete(@LoginMember Long userId, @PathVariable Long cctvId);
+    @Operation(summary = "MASTER 회원이 CCTV 퇴출", description = "담당자: 양원채")
+    Api<?> out(@LoginMember Long userId, @PathVariable Long cctvId);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvController.java
@@ -16,9 +16,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class CctvController implements CctvApi {
     private final CctvService cctvService;
 
-    @DeleteMapping("/{cctvId}")
-    public Api<?> delete(@LoginMember Long userId, @PathVariable("cctvId") Long cctvId) {
-        cctvService.deleteById(userId, cctvId);
+    @DeleteMapping("/{cctvId}/out")
+    public Api<?> out(@LoginMember Long userId, @PathVariable("cctvId") Long cctvId) {
+        cctvService.outById(userId, cctvId);
         return Api.success(CctvSuccessType.DELETE_CCTV);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/repository/CctvRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/repository/CctvRepository.java
@@ -2,14 +2,13 @@ package org.ioteatime.meonghanyangserver.cctv.repository;
 
 import java.util.Optional;
 import org.ioteatime.meonghanyangserver.cctv.domain.CctvEntity;
-import org.ioteatime.meonghanyangserver.cctv.dto.db.CctvWithDeviceId;
 
 public interface CctvRepository {
     boolean existsByKvsChannelName(String kvsChannelName);
 
     void deleteById(Long cctvId);
 
-    Optional<CctvWithDeviceId> findByIdWithDeviceId(Long cctvId);
-
     CctvEntity save(CctvEntity cctv);
+
+    Optional<CctvEntity> findById(Long cctvId);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/repository/CctvRepositoryImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/repository/CctvRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.cctv.domain.CctvEntity;
-import org.ioteatime.meonghanyangserver.cctv.dto.db.CctvWithDeviceId;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -23,24 +22,12 @@ public class CctvRepositoryImpl implements CctvRepository {
     }
 
     @Override
-    public Optional<CctvWithDeviceId> findByIdWithDeviceId(Long cctvId) {
-        //        return Optional.ofNullable(
-        //                jpaQueryFactory
-        //                        .select(
-        //                                Projections.constructor(
-        //                                        CctvWithDeviceId.class,
-        //                                        cctvEntity.id.as("cctvId"),
-        //                                        cctvEntity.kvsChannelName.as("kvsChannelName"),
-        //                                        cctvEntity.device.id.as("deviceId")))
-        //                        .from(cctvEntity)
-        //                        .join(cctvEntity.device, deviceEntity)
-        //                        .where(cctvEntity.id.eq(cctvId))
-        //                        .fetchOne());
-        return null;
+    public CctvEntity save(CctvEntity cctv) {
+        return jpaCctvRepository.save(cctv);
     }
 
     @Override
-    public CctvEntity save(CctvEntity cctv) {
-        return jpaCctvRepository.save(cctv);
+    public Optional<CctvEntity> findById(Long cctvId) {
+        return jpaCctvRepository.findById(cctvId);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/service/CctvService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/service/CctvService.java
@@ -2,7 +2,7 @@ package org.ioteatime.meonghanyangserver.cctv.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.ioteatime.meonghanyangserver.cctv.dto.db.CctvWithDeviceId;
+import org.ioteatime.meonghanyangserver.cctv.domain.CctvEntity;
 import org.ioteatime.meonghanyangserver.cctv.repository.CctvRepository;
 import org.ioteatime.meonghanyangserver.clients.kvs.KvsClient;
 import org.ioteatime.meonghanyangserver.common.exception.BadRequestException;
@@ -16,25 +16,21 @@ import org.springframework.stereotype.Service;
 public class CctvService {
     private final KvsClient kvsClient;
     private final CctvRepository cctvRepository;
-    private final GroupMemberRepository deviceRepository;
+    private final GroupMemberRepository groupMemberRepository;
 
     @Transactional
-    public void deleteById(Long userId, Long cctvId) {
-        // Device 테이블에서 userId를 조회하여 role 을 확인
-        if (deviceRepository.isParcitipantUserId(userId)) {
-            // PARTICIPANT 이면 CCTV 삭제 실패
+    public void outById(Long memberId, Long cctvId) {
+        // Master 권한을 가진 회원만 cctv 퇴출 가능
+        if (!groupMemberRepository.isMasterMember(memberId)) {
             throw new BadRequestException(CctvErrorType.ONLY_MASTER_CAN_DELETE);
         }
-        // MASTER 이거나, CCTV(자기자신)이면 CCTV 퇴출(나가기) 가능
-        CctvWithDeviceId cctv =
+        CctvEntity cctv =
                 cctvRepository
-                        .findByIdWithDeviceId(cctvId)
+                        .findById(cctvId)
                         .orElseThrow(() -> new NotFoundException(CctvErrorType.NOT_FOUND));
         // 1. KVS 시그널링 채널 삭제
-        kvsClient.deleteSignalingChannel(cctv.kvsChannelName());
+        kvsClient.deleteSignalingChannel(cctv.getKvsChannelName());
         // 2. CCTV 테이블에서 삭제
         cctvRepository.deleteById(cctvId);
-        // 3. Device 테이블에서 삭제
-        deviceRepository.deleteById(cctv.deviceId());
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/config/RedisConfig.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/config/RedisConfig.java
@@ -19,11 +19,14 @@ public class RedisConfig {
     @Value("${spring.data.redis.password}")
     private String password;
 
+    @Value("${spring.data.redis.port}")
+    private String port;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
         redisConfiguration.setHostName(host);
-        redisConfiguration.setPort(6379);
+        redisConfiguration.setPort(Integer.parseInt(port));
         redisConfiguration.setPassword(password);
         return new LettuceConnectionFactory(redisConfiguration);
     }

--- a/src/main/java/org/ioteatime/meonghanyangserver/groupmember/repository/GroupMemberRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/groupmember/repository/GroupMemberRepository.java
@@ -5,7 +5,7 @@ import org.ioteatime.meonghanyangserver.group.domain.GroupEntity;
 import org.ioteatime.meonghanyangserver.groupmember.doamin.GroupMemberEntity;
 
 public interface GroupMemberRepository {
-    GroupMemberEntity createGroupMember(GroupMemberEntity groupMemberEntity);
+    GroupMemberEntity save(GroupMemberEntity groupMemberEntity);
 
     boolean existsGroupMember(Long memberId);
 
@@ -13,9 +13,7 @@ public interface GroupMemberRepository {
 
     GroupEntity findGroupMember(Long memberId);
 
-    boolean isParcitipantUserId(Long userId);
-
     void deleteById(Long id);
 
-    GroupMemberEntity save(GroupMemberEntity device);
+    boolean isMasterMember(Long memberId);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/groupmember/repository/GroupMemberRepositoryImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/groupmember/repository/GroupMemberRepositoryImpl.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.group.domain.GroupEntity;
 import org.ioteatime.meonghanyangserver.groupmember.doamin.GroupMemberEntity;
+import org.ioteatime.meonghanyangserver.groupmember.doamin.enums.GroupMemberRole;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,7 +18,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public GroupMemberEntity createGroupMember(GroupMemberEntity groupMemberEntity) {
+    public GroupMemberEntity save(GroupMemberEntity groupMemberEntity) {
         return jpaGroupMemberRepository.save(groupMemberEntity);
     }
 
@@ -41,28 +42,22 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepository {
     }
 
     @Override
-    public boolean isParcitipantUserId(Long userId) {
-        //        return !jpaQueryFactory
-        //                .select(deviceEntity.role)
-        //                .from(deviceEntity)
-        //                .where(
-        //                        deviceEntity
-        //                                .member
-        //                                .id
-        //                                .eq(userId)
-        //                                .and(deviceEntity.role.eq(DeviceRole.ROLE_PARTICIPANT)))
-        //                .fetch()
-        //                .isEmpty();
-        return true;
-    }
-
-    @Override
     public void deleteById(Long id) {
         jpaGroupMemberRepository.deleteById(id);
     }
 
     @Override
-    public GroupMemberEntity save(GroupMemberEntity device) {
-        return jpaGroupMemberRepository.save(device);
+    public boolean isMasterMember(Long memberId) {
+        return !jpaQueryFactory
+                .select(groupMemberEntity.role)
+                .from(groupMemberEntity)
+                .where(
+                        groupMemberEntity
+                                .member
+                                .id
+                                .eq(memberId)
+                                .and(groupMemberEntity.role.eq(GroupMemberRole.ROLE_MASTER)))
+                .fetch()
+                .isEmpty();
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/groupmember/service/GroupMemberService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/groupmember/service/GroupMemberService.java
@@ -29,7 +29,7 @@ public class GroupMemberService {
             String thingId) {
         GroupMemberEntity groupMember =
                 GroupMemberEntityMapper.from(groupEntity, memberEntity, groupMemberRole, thingId);
-        groupMemberRepository.createGroupMember(groupMember);
+        groupMemberRepository.save(groupMember);
     }
 
     public boolean existsGroupMember(Long memberId) {


### PR DESCRIPTION
### 📋 상세 설명
- CCTV가 로그인이 가능했던 방식에서는 퇴출과 나가기를 하나의 메서드에서 진행이 가능했습니다.
- 하지만 CCTV가 로그인 없이 나가기 요청을 보낼 예정이므로, MASTER 권한 회원이 퇴출하는 코드가 분리되어야 했습니다.
- CCTV 나가기의 경우 IoT를 활용한 별도의 인증 절차가 필요할 것 같습니다.
- 테스트코드로 성공하는 것을 확인했습니다.