### PR TITLE
feat: FCM 푸시 알림 Topic 구독, 메시지 전송 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ build/
 !**/src/test/**/build/
 **/application-secret.properties
 /tokens/**
-**/client_secret.json
+**/**.json
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,9 @@ dependencies {
 
     // Test
     runtimeOnly 'com.h2database:h2'
+
+    // FCM
+    implementation 'com.google.firebase:firebase-admin:9.4.1'
 }
 
 spotless {

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     env_file: .env
     volumes:
       - "./client_secret.json:/client_secret.json"
+      - "./monghanyang-21fad-54f38c79a642.json:/monghanyang-21fad-54f38c79a642.json"
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.server.rule=Host(`api.meonghanyang.kro.kr`)"

--- a/src/main/java/org/ioteatime/meonghanyangserver/clients/google/FcmClient.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/clients/google/FcmClient.java
@@ -1,0 +1,64 @@
+package org.ioteatime.meonghanyangserver.clients.google;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import org.ioteatime.meonghanyangserver.common.exception.InternalServerException;
+import org.ioteatime.meonghanyangserver.common.type.FcmErrorType;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FcmClient {
+    @Value("${google.application-credentials}")
+    private String applicationCredentials;
+
+    public void init() {
+        try {
+            InputStream refreshToken =
+                    new ClassPathResource(applicationCredentials).getInputStream();
+
+            FirebaseOptions options =
+                    FirebaseOptions.builder()
+                            .setCredentials(GoogleCredentials.fromStream(refreshToken))
+                            .build();
+
+            FirebaseApp.initializeApp(options);
+        } catch (IOException e) {
+            throw new InternalServerException(FcmErrorType.IO);
+        }
+    }
+
+    public void subTopic(String token, String topic) {
+        try {
+            TopicManagementResponse response =
+                    FirebaseMessaging.getInstance()
+                            .subscribeToTopic(Collections.singletonList(token), topic);
+            System.out.println(response.getSuccessCount() + " tokens were subscribed successfully");
+        } catch (FirebaseMessagingException e) {
+            e.printStackTrace();
+            throw new InternalServerException(FcmErrorType.SEND_FAILED);
+        }
+    }
+
+    public void sendPush(String title, String content, String topic) {
+        Message message =
+                Message.builder()
+                        .setNotification(
+                                Notification.builder().setTitle(title).setBody(content).build())
+                        .setTopic(topic)
+                        .build();
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            System.out.println(response);
+        } catch (FirebaseMessagingException e) {
+            e.printStackTrace();
+            throw new InternalServerException(FcmErrorType.SEND_FAILED);
+        }
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/FcmErrorType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/FcmErrorType.java
@@ -1,0 +1,24 @@
+package org.ioteatime.meonghanyangserver.common.type;
+
+public enum FcmErrorType implements ErrorTypeCode {
+    IO("IOEXCEPTION", "FCM 서비스 계정 설정 중 IO 오류가 발생하였습니다."),
+    SEND_FAILED("SERVER ERROR", "푸시 알림 전송에 실패하였습니다.");
+
+    private final String message;
+    private final String description;
+
+    FcmErrorType(String message, String description) {
+        this.message = message;
+        this.description = description;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/FcmSuccessType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/FcmSuccessType.java
@@ -1,0 +1,30 @@
+package org.ioteatime.meonghanyangserver.common.type;
+
+public enum FcmSuccessType implements SuccessTypeCode {
+    SAVE(200, "OK", "FCM 토큰 저장에 성공하였습니다");
+
+    private final Integer code;
+    private final String message;
+    private final String description;
+
+    FcmSuccessType(Integer code, String message, String description) {
+        this.code = code;
+        this.message = message;
+        this.description = description;
+    }
+
+    @Override
+    public Integer getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/fcm/controller/FcmApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/fcm/controller/FcmApi.java
@@ -1,0 +1,13 @@
+package org.ioteatime.meonghanyangserver.fcm.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.ioteatime.meonghanyangserver.common.api.Api;
+import org.ioteatime.meonghanyangserver.fcm.dto.request.SaveFcmTokenRequest;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Fcm Api", description = "알림 관련 API 목록입니다.")
+public interface FcmApi {
+    @Operation(summary = "FCM 토큰 저장", description = "담당자: 양원채")
+    Api<?> saveToken(@RequestBody SaveFcmTokenRequest createFcmTokenRequest);
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/fcm/controller/FcmController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/fcm/controller/FcmController.java
@@ -1,0 +1,23 @@
+package org.ioteatime.meonghanyangserver.fcm.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.ioteatime.meonghanyangserver.common.api.Api;
+import org.ioteatime.meonghanyangserver.common.type.FcmSuccessType;
+import org.ioteatime.meonghanyangserver.fcm.dto.request.SaveFcmTokenRequest;
+import org.ioteatime.meonghanyangserver.fcm.service.FcmService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/open-api/fcm") // 테스트 후 api로 변경하기
+public class FcmController implements FcmApi {
+    private final FcmService fcmService;
+
+    @PostMapping("/token")
+    public Api<?> saveToken(SaveFcmTokenRequest createFcmTokenRequest) {
+        fcmService.saveToken(createFcmTokenRequest.token());
+        return Api.success(FcmSuccessType.SAVE);
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/fcm/dto/request/SaveFcmTokenRequest.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/fcm/dto/request/SaveFcmTokenRequest.java
@@ -1,0 +1,9 @@
+package org.ioteatime.meonghanyangserver.fcm.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "FCM 토큰 저장 요청")
+public record SaveFcmTokenRequest(
+        @NotNull @Schema(description = "FCM 토큰", example = "d2YO_jG7Q4W0JH-dYw666M:APA9..")
+                String token) {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/fcm/service/FcmService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/fcm/service/FcmService.java
@@ -1,0 +1,22 @@
+package org.ioteatime.meonghanyangserver.fcm.service;
+
+import org.ioteatime.meonghanyangserver.clients.google.FcmClient;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FcmService {
+    private final FcmClient fcmClient;
+
+    public FcmService(FcmClient fcmClient) {
+        this.fcmClient = fcmClient;
+        fcmClient.init();
+    }
+
+    public void saveToken(String token) {
+        // TODO. 토큰을 DB에 저장하기
+        // TODO. 로그인 계정 정보 불러오는 방식으로 구현하기
+        // 현재는 테스트를 위해 token이 자동으로 hello Topic을 구독하고, 곧바로 hello Topic에 메시지를 보냄
+        fcmClient.subTopic(token, "hello");
+        fcmClient.sendPush("test-message", "test-content", "hello");
+    }
+}

--- a/src/main/resources/application-key.yaml
+++ b/src/main/resources/application-key.yaml
@@ -7,6 +7,7 @@ token:
 google:
   service-account: ${GCP_SERVICE_ACCOUNT}
   official-gmail: ${OFFICIAL_GMAIL}
+  application-credentials: ${GOOGLE_APPLICATION_CREDENTIALS}
 
 aws:
   kvs:


### PR DESCRIPTION
### 📋 상세 설명
- 원래는 클라이언트로부터 발급된 token을 받으면, DB에 저장하는 로직이 구현되어야 합니다.
- 모바일 클라이언트와 연결이 잘 되는지 테스트하기 위해, 해당 API에 Topic을 구독하고 메시지를 전송하는 기능만 먼저 구현하였습니다.
- Swagger로는 정상동작하는 것을 확인했습니다.

### 📸 스크린샷
<img width="928" alt="Screenshot 2024-11-14 at 13 54 03" src="https://github.com/user-attachments/assets/2adb4aa5-eac3-487c-9962-3e3d68102d38">