### PR TITLE
feat: Group 생성 시 FCM Topic을 랜덤으로 생성하여 저장

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/common/utils/RandomStringGenerator.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/utils/RandomStringGenerator.java
@@ -1,0 +1,21 @@
+package org.ioteatime.meonghanyangserver.common.utils;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RandomStringGenerator {
+    public String generate() {
+        int leftLimit = 48; // numeral '0'
+        int rightLimit = 122; // letter 'z'
+        int targetStringLength = 10;
+        Random random = ThreadLocalRandom.current();
+
+        return random.ints(leftLimit, rightLimit + 1)
+                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+                .limit(targetStringLength)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/group/domain/GroupEntity.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/group/domain/GroupEntity.java
@@ -27,6 +27,9 @@ public class GroupEntity {
     @Column(nullable = false, length = 100)
     private String groupName;
 
+    @Column(nullable = false, length = 100)
+    private String fcmTopic;
+
     @Column @CreatedDate private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "group")

--- a/src/main/java/org/ioteatime/meonghanyangserver/group/mapper/GroupEntityMapper.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/group/mapper/GroupEntityMapper.java
@@ -4,7 +4,11 @@ import java.time.LocalDateTime;
 import org.ioteatime.meonghanyangserver.group.domain.GroupEntity;
 
 public class GroupEntityMapper {
-    public static GroupEntity toEntity(String groupName) {
-        return GroupEntity.builder().groupName(groupName).createdAt(LocalDateTime.now()).build();
+    public static GroupEntity toEntity(String groupName, String fcmTopic) {
+        return GroupEntity.builder()
+                .groupName(groupName)
+                .fcmTopic(fcmTopic)
+                .createdAt(LocalDateTime.now())
+                .build();
     }
 }


### PR DESCRIPTION
### 📋 상세 설명
- Group을 생성할 때 FCM Topic 문자열을 랜덤으로 생성하여 저장합니다.
- prefix로 memberId를 추가하여 Topic 중복을 피합니다.

### 📸 스크린샷
<img width="844" alt="Screenshot 2024-11-14 at 17 31 07" src="https://github.com/user-attachments/assets/206c9a61-445a-48a9-91b6-b59fde0ca637">
<img width="366" alt="Screenshot 2024-11-14 at 17 35 21" src="https://github.com/user-attachments/assets/115983e7-fa31-4811-82dd-9ba4519ff074">

### 📚 자료
- https://linkeverything.github.io/java/java-random-string/