### PR TITLE
fix: FCM 토큰 갱신 updated_at 반영 안 되는 이슈 해결

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/member/domain/MemberEntity.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/domain/MemberEntity.java
@@ -64,6 +64,7 @@ public class MemberEntity {
 
     public MemberEntity updateFcmToken(String token) {
         this.fcmToken = token;
+        this.updatedAt = LocalDateTime.now();
         return this;
     }
 }

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -10,4 +10,4 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100
     hibernate:
-      ddl-auto: create
+      ddl-auto: update


### PR DESCRIPTION
### 📋 상세 설명
- FCM 토큰을 갱신할 때, 같은 필드인 경우 updated_at이 동작하지 않았습니다.
- 갱신 시 updated_at을 현재 시간으로 업데이트 하도록 수정합니다.