### PR TITLE
feat: IoT Core, MQTT 연결 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,6 @@ dependencies {
     // IOT
     implementation 'com.amazonaws:aws-java-sdk-iot:1.12.778'
     implementation 'software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk:1.21.0'
-
 }
 
 spotless {

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,11 @@ dependencies {
 
     // SES
     implementation 'com.amazonaws:aws-java-sdk-ses:1.12.778'
+
+    // IOT
+    implementation 'com.amazonaws:aws-java-sdk-iot:1.12.778'
+    implementation 'software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk:1.21.0'
+
 }
 
 spotless {

--- a/src/main/java/org/ioteatime/meonghanyangserver/MeongHaNyangServerApplication.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/MeongHaNyangServerApplication.java
@@ -2,10 +2,12 @@ package org.ioteatime.meonghanyangserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class MeongHaNyangServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/ioteatime/meonghanyangserver/clients/iot/IotMqttClient.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/clients/iot/IotMqttClient.java
@@ -1,0 +1,26 @@
+package org.ioteatime.meonghanyangserver.clients.iot;
+
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
+import software.amazon.awssdk.crt.mqtt.MqttMessage;
+import software.amazon.awssdk.crt.mqtt.QualityOfService;
+
+@Service
+@RequiredArgsConstructor
+public class IotMqttClient {
+    @Value("${aws.iot-end-point}")
+    private String endpoint;
+
+    private final MqttClientConnection mqttClientConnection;
+
+    public void subscribe(String topic, Consumer<MqttMessage> handler) {
+        mqttClientConnection.subscribe(topic, QualityOfService.AT_LEAST_ONCE, handler);
+    }
+
+    public void publish(MqttMessage message) {
+        mqttClientConnection.publish(message);
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/AwsErrorType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/AwsErrorType.java
@@ -1,7 +1,8 @@
 package org.ioteatime.meonghanyangserver.common.type;
 
 public enum AwsErrorType implements ErrorTypeCode {
-    KVS_CHANNEL_NAME_NOT_FOUND("NOT FOUND", "채널 이름에 해당하는 KVS 채널을 찾을 수 없습니다.");
+    KVS_CHANNEL_NAME_NOT_FOUND("NOT FOUND", "채널 이름에 해당하는 KVS 채널을 찾을 수 없습니다."),
+    IOT_MQTT_CONNECTION_FAILED("SERVER ERROR", "IoT MQTT 연결에 실패하였습니다.");
 
     private final String message;
     private final String description;

--- a/src/main/java/org/ioteatime/meonghanyangserver/config/AwsProperties.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/config/AwsProperties.java
@@ -1,0 +1,14 @@
+package org.ioteatime.meonghanyangserver.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "aws")
+public record AwsProperties(
+        String kvsAccessKey,
+        String kvsSecretKey,
+        String sesAccessKey,
+        String sesSecretKey,
+        String iotAccessKey,
+        String iotSecretKey,
+        String iotEndpoint,
+        String iotClientId) {}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -16,7 +16,3 @@ spring:
       location: C:\\multipart\\uploads\\
       max-file-size: 10MB
       max-request-size: 10MB
-
-logging:
-  level:
-    root: debug

--- a/src/main/resources/application-key.yaml
+++ b/src/main/resources/application-key.yaml
@@ -11,9 +11,11 @@ google:
   application-credentials: ${GOOGLE_APPLICATION_CREDENTIALS}
 
 aws:
-  kvs:
-    access-key: ${AWS_KVS_ACCESS_KEY}
-    secret-key: ${AWS_KVS_SECRET_KEY}
-  ses:
-    access-key: ${AWS_SES_ACCESS_KEY}
-    secret-key: ${AWS_SES_SECRET_KEY}
+  kvs-access-key: ${AWS_KVS_ACCESS_KEY}
+  kvs-secret-key: ${AWS_KVS_SECRET_KEY}
+  ses-access-key: ${AWS_SES_ACCESS_KEY}
+  ses-secret-key: ${AWS_SES_SECRET_KEY}
+  iot-access-key: ${AWS_IOT_ACCESS_KEY}
+  iot-secret-key: ${AWS_IOT_SECRET_KEY}
+  iot-endpoint: ${AWS_IOT_ENDPOINT}
+  iot-client-id: ${AWS_IOT_CLIENT_ID}


### PR DESCRIPTION
### 📋 상세 설명
- IoT Core, MQTT 연결을 구현하였습니다.
- 서버가 실행되면 즉시 연결이 진행됩니다.
- 빈으로 등록된 `MqttClientConnection`을 `IotMqttClient`가 사용하게 됩니다.
- 기본 pub, sub을 구현해 두었습니다.

### 📸 스크린샷
<img width="464" alt="Screenshot 2024-11-21 at 16 07 53" src="https://github.com/user-attachments/assets/2480952f-cd2b-4143-b6ee-53f7802625db">

### 📚 자료
- 서버가 기본적으로 sub할 필요가 있는 topic에 대해 구현이 필요합니다.
- 그러한 topic들을 나열하고, 서버가 실행될 때 즉시 sub할 수 있도록 구현해야 합니다.