### PR TITLE
feat: 회원 탈퇴 연관관계 끊기 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.777'
 
     // IOT
+    implementation 'software.amazon.awssdk:iot:2.29.17'
     implementation 'com.amazonaws:aws-java-sdk-iot:1.12.778'
     implementation 'software.amazon.awssdk.iotdevicesdk:aws-iot-device-sdk:1.21.0'
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/repository/CctvRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/repository/CctvRepository.java
@@ -15,7 +15,7 @@ public interface CctvRepository {
 
     Optional<CctvEntity> findById(Long cctvId);
 
-    void deleteByCctvId(Long groupId);
+    void deleteByGroupId(Long groupId);
 
     Optional<CctvEntity> findByCctvId(Long thingId);
 

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/repository/CctvRepositoryImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/repository/CctvRepositoryImpl.java
@@ -41,7 +41,7 @@ public class CctvRepositoryImpl implements CctvRepository {
     }
 
     @Override
-    public void deleteByCctvId(Long groupId) {
+    public void deleteByGroupId(Long groupId) {
         jpaCctvRepository.deleteByGroupId(groupId);
     }
 

--- a/src/main/java/org/ioteatime/meonghanyangserver/groupmember/service/GroupMemberService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/groupmember/service/GroupMemberService.java
@@ -136,7 +136,7 @@ public class GroupMemberService {
         if (groupMember.getRole().equals(GroupMemberRole.ROLE_MASTER)) {
             // 방장 퇴장
             groupMemberRepository.deleteByGroupId(groupId);
-            cctvRepository.deleteByCctvId(groupId);
+            cctvRepository.deleteByGroupId(groupId);
             groupRepository.deleteById(groupId);
         } else {
             // 참여자 퇴장

--- a/src/main/java/org/ioteatime/meonghanyangserver/video/repository/JpaVideoRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/video/repository/JpaVideoRepository.java
@@ -3,4 +3,6 @@ package org.ioteatime.meonghanyangserver.video.repository;
 import org.ioteatime.meonghanyangserver.video.domain.VideoEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface JpaVideoRepository extends JpaRepository<VideoEntity, Long> {}
+public interface JpaVideoRepository extends JpaRepository<VideoEntity, Long> {
+    void deleteAllByGroupId(Long groupId);
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/video/repository/VideoRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/video/repository/VideoRepository.java
@@ -5,4 +5,6 @@ import org.ioteatime.meonghanyangserver.video.domain.VideoEntity;
 
 public interface VideoRepository {
     Optional<VideoEntity> findById(Long videoId);
+
+    void deleteAllByGroupId(Long groupId);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/video/repository/VideoRepositoryImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/video/repository/VideoRepositoryImpl.java
@@ -16,4 +16,9 @@ public class VideoRepositoryImpl implements VideoRepository {
     public Optional<VideoEntity> findById(Long videoId) {
         return jpaVideoRepository.findById(videoId);
     }
+
+    @Override
+    public void deleteAllByGroupId(Long groupId) {
+        jpaVideoRepository.deleteAllByGroupId(groupId);
+    }
 }


### PR DESCRIPTION
### 📋 상세 설명
- 회원 탈퇴를 구현하였습니다. 탈퇴 시 연관관계를 끊어가는 과정에서 복잡성이 증가했습니다.
- 논리는 다음과 같습니다.

탈퇴하는 사람이 MASTER이면 group을 삭제해야 함
memberId 기준으로 groupMember 통해 groupId 조회
groupId 기준으로 video 조회하여 삭제 (S3 배치 작업 추가 필요)
groupId 기준으로 cctv 조회하여 정보 목록 확인
cctv 목록을 순회하여 kvs 채널 삭제
cctv 상태 shadow에서 kvsChannelDeleteRequested 필드 true로 pub -> (iot 기기 삭제는 모바일에서)
groupMember 삭제
group 삭제
member 삭제
(MASTER iot 기기 삭제 모바일에서 진행하기)

그렇지 않으면 groupMember와 member만 삭제
(PARTICIPANT iot 기기 삭제 모바일에서 진행하기)

### 📸 스크린샷
<img width="844" alt="Screenshot 2024-11-21 at 17 40 02" src="https://github.com/user-attachments/assets/b4cf05f1-33ad-4520-9121-22829ad526d7">

### 📚 자료
- [AWS IoT Shadow docs](https://aws.github.io/aws-iot-device-sdk-java-v2/software/amazon/awssdk/iot/iotshadow/IotShadowClient.html#PublishUpdateShadow(software.amazon.awssdk.iot.iotshadow.model.UpdateShadowRequest,software.amazon.awssdk.crt.mqtt.QualityOfService))
- [Update Shadow docs](https://docs.aws.amazon.com/ko_kr/iot/latest/developerguide/device-shadow-mqtt.html#update-pub-sub-topic)