### PR TITLE
feat: 로그아웃 구현

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/service/AuthService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/service/AuthService.java
@@ -56,7 +56,11 @@ public class AuthService {
         if (accessToken.isEmpty() || refreshToken.isEmpty()) {
             throw new NotFoundException(AuthErrorType.TOKEN_NOT_FOUND);
         }
-        RefreshToken refreshTokenEntity = RefreshToken.builder().refreshToken(refreshToken).build();
+        RefreshToken refreshTokenEntity =
+                RefreshToken.builder()
+                        .memberId(memberEntity.getId())
+                        .refreshToken(refreshToken)
+                        .build();
 
         refreshTokenRepository.save(refreshTokenEntity);
         accessToken = jwtUtils.includeBearer(accessToken);

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthSuccessType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthSuccessType.java
@@ -10,7 +10,7 @@ public enum AuthSuccessType implements SuccessTypeCode {
     DELETE_USER(200, "OK", "회원 삭제에 성공하였습니다."),
     UPDATE_PASSWORD(200, "OK", "비밀번호 수정에 성공하였습니다."),
     VERIFY_EMAIL_CODE(200, "OK", "이메일 인증 코드 검증에 성공하였습니다."),
-    SIGN_OUT(200, "OK", "로그아웃에 성공하였습니다..");
+    SIGN_OUT(200, "OK", "로그아웃에 성공하였습니다.");
 
 
     private final Integer code;

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthSuccessType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthSuccessType.java
@@ -9,7 +9,9 @@ public enum AuthSuccessType implements SuccessTypeCode {
     GET_USER_DETAIL(200, "OK", "회원 단건 조회에 성공하였습니다."),
     DELETE_USER(200, "OK", "회원 삭제에 성공하였습니다."),
     UPDATE_PASSWORD(200, "OK", "비밀번호 수정에 성공하였습니다."),
-    VERIFY_EMAIL_CODE(200, "OK", "이메일 인증 코드 검증에 성공하였습니다.");
+    VERIFY_EMAIL_CODE(200, "OK", "이메일 인증 코드 검증에 성공하였습니다."),
+    SIGN_OUT(200, "OK", "로그아웃에 성공하였습니다..");
+
 
     private final Integer code;
     private final String message;

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthSuccessType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthSuccessType.java
@@ -12,7 +12,6 @@ public enum AuthSuccessType implements SuccessTypeCode {
     VERIFY_EMAIL_CODE(200, "OK", "이메일 인증 코드 검증에 성공하였습니다."),
     SIGN_OUT(200, "OK", "로그아웃에 성공하였습니다.");
 
-
     private final Integer code;
     private final String message;
     private final String description;

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/utils/JwtUtils.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/utils/JwtUtils.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 import org.ioteatime.meonghanyangserver.member.domain.MemberEntity;
+import org.ioteatime.meonghanyangserver.redis.AccessTokenRepository;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
@@ -18,8 +19,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtUtils {
     private final SecretKey key;
+    private final AccessTokenRepository accessTokenRepository;
 
-    public JwtUtils(Environment env) {
+    public JwtUtils(Environment env, AccessTokenRepository accessTokenRepository) {
+        this.accessTokenRepository = accessTokenRepository;
         String secretKeyString = env.getProperty("token.secret");
         byte[] decodedKey = Base64.getDecoder().decode(secretKeyString);
         this.key = Keys.hmacShaKeyFor(decodedKey);
@@ -71,7 +74,7 @@ public class JwtUtils {
         return String.valueOf(claims.get("name"));
     }
 
-    private Date getExpirationDateFromToken(String token) {
+    public Date getExpirationDateFromToken(String token) {
         final Claims claims = getAllClaimsFromToken(token);
         return claims.getExpiration();
     }
@@ -103,5 +106,10 @@ public class JwtUtils {
 
     public String includeBearer(String token) {
         return "Bearer " + token;
+    }
+
+    //access token 블랙리스트 유무 확인
+    public boolean blackListAccessToken(String token){
+        return accessTokenRepository.existsByAccessToken(token);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/utils/JwtUtils.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/utils/JwtUtils.java
@@ -108,8 +108,8 @@ public class JwtUtils {
         return "Bearer " + token;
     }
 
-    //access token 블랙리스트 유무 확인
-    public boolean blackListAccessToken(String token){
+    // access token 블랙리스트 유무 확인
+    public boolean blackListAccessToken(String token) {
         return accessTokenRepository.existsByAccessToken(token);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/config/SecurityConfig.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package org.ioteatime.meonghanyangserver.config;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.ioteatime.meonghanyangserver.filter.ExceptionHandlerFilter;
 import org.ioteatime.meonghanyangserver.filter.JwtRequestFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +24,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtRequestFilter jwtRequestFilter;
+    private final ExceptionHandlerFilter exceptionHandlerFilter;
 
     @Bean
     BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -39,7 +41,8 @@ public class SecurityConfig {
 
         http.httpBasic(HttpBasicConfigurer::disable);
 
-        http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(exceptionHandlerFilter, JwtRequestFilter.class);
 
         http.authorizeHttpRequests(
                 (auth) ->

--- a/src/main/java/org/ioteatime/meonghanyangserver/config/SecurityConfig.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.filter.ExceptionHandlerFilter;
 import org.ioteatime.meonghanyangserver.filter.JwtRequestFilter;
+import org.ioteatime.meonghanyangserver.handler.CustomLogoutHandler;
+import org.ioteatime.meonghanyangserver.handler.CustomLogoutSuccessHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -25,6 +27,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
     private final JwtRequestFilter jwtRequestFilter;
     private final ExceptionHandlerFilter exceptionHandlerFilter;
+    private final CustomLogoutHandler customLogoutHandler;
+    private final CustomLogoutSuccessHandler customLogoutSuccessHandler;
 
     @Bean
     BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -43,7 +47,6 @@ public class SecurityConfig {
 
         http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(exceptionHandlerFilter, JwtRequestFilter.class);
-
         http.authorizeHttpRequests(
                 (auth) ->
                         auth.requestMatchers(
@@ -55,7 +58,11 @@ public class SecurityConfig {
                                 .permitAll()
                                 .anyRequest()
                                 .authenticated());
-
+        http.logout(
+                logout ->
+                        logout.logoutUrl("/api/member/sign-out")
+                                .addLogoutHandler(customLogoutHandler)
+                                .logoutSuccessHandler(customLogoutSuccessHandler));
         http.sessionManagement(
                 session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 

--- a/src/main/java/org/ioteatime/meonghanyangserver/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/filter/ExceptionHandlerFilter.java
@@ -1,0 +1,42 @@
+package org.ioteatime.meonghanyangserver.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.ioteatime.meonghanyangserver.common.api.Api;
+import org.ioteatime.meonghanyangserver.common.exception.ApiExceptionImpl;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ApiExceptionImpl exception) {
+            exceptionHandle(response, exception);
+        }
+    }
+
+    // jwtRequest filter exception handle
+    private void exceptionHandle(HttpServletResponse response, ApiExceptionImpl exception)
+            throws IOException {
+        response.setStatus(exception.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Api<Object> apiResponse = Api.fail(exception);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/filter/JwtRequestFilter.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/filter/JwtRequestFilter.java
@@ -1,6 +1,5 @@
 package org.ioteatime.meonghanyangserver.filter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,7 +7,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.exception.*;
 import org.ioteatime.meonghanyangserver.common.type.AuthErrorType;
 import org.ioteatime.meonghanyangserver.common.utils.JwtUtils;
@@ -35,71 +33,54 @@ public class JwtRequestFilter extends OncePerRequestFilter {
     protected void doFilterInternal(
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        try {
-            String uri = request.getRequestURI();
-            if (uri.contains("/open-api")
-                    || uri.contains("/swagger-ui")
-                    || uri.contains("/v3/api-docs")
-                    || uri.contains("/static")) {
-                filterChain.doFilter(request, response);
-                return;
-            }
 
-            String jwtToken = null;
-            Long jwtId = null;
+        String uri = request.getRequestURI();
+        if (uri.contains("/open-api")
+                || uri.contains("/swagger-ui")
+                || uri.contains("/v3/api-docs")
+                || uri.contains("/static")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
-            String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String jwtToken = null;
+        Long jwtId = null;
 
-            if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-                jwtToken = authorizationHeader.substring(7);
-                // access token 블랙리스트 확인
-                if (jwtUtils.blackListAccessToken(jwtToken)) {
-                    throw new UnauthorizedException(AuthErrorType.HEADER_INVALID);
-                }
-                jwtId = jwtUtils.getIdFromToken(jwtToken);
-                log.debug("jwt : ", jwtToken);
-            } else {
-                log.error("Authorization 헤더 누락 또는 토큰 형식 오류");
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            jwtToken = authorizationHeader.substring(7);
+            // access token 블랙리스트 확인
+            if (jwtUtils.blackListAccessToken(jwtToken)) {
                 throw new UnauthorizedException(AuthErrorType.HEADER_INVALID);
             }
-            if (jwtId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-                MemberEntity entity =
-                        memberRepository
-                                .findById(jwtId)
-                                .orElseThrow(() -> new NotFoundException(AuthErrorType.NOT_FOUND));
-
-                log.debug(entity.getEmail());
-                if (jwtUtils.validateToken(jwtToken, entity)) {
-                    CustomUserDetail customUserDetail = new CustomUserDetail(entity);
-                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-                            new UsernamePasswordAuthenticationToken(
-                                    customUserDetail, null, customUserDetail.getAuthorities());
-                    usernamePasswordAuthenticationToken.setDetails(
-                            new WebAuthenticationDetailsSource().buildDetails(request));
-                    SecurityContextHolder.getContext()
-                            .setAuthentication(usernamePasswordAuthenticationToken);
-                } else {
-                    SecurityContextHolder.getContext().setAuthentication(null);
-                    return;
-                }
-                filterChain.doFilter(request, response);
-            }
-        } catch (ApiExceptionImpl exception) {
-            exceptionHandle(response, exception);
+            jwtId = jwtUtils.getIdFromToken(jwtToken);
+            log.debug("jwt : ", jwtToken);
+        } else {
+            log.error("Authorization 헤더 누락 또는 토큰 형식 오류");
+            throw new UnauthorizedException(AuthErrorType.HEADER_INVALID);
         }
-    }
+        if (jwtId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            MemberEntity entity =
+                    memberRepository
+                            .findById(jwtId)
+                            .orElseThrow(() -> new NotFoundException(AuthErrorType.NOT_FOUND));
 
-    // jwtRequest filter exception handle
-    private void exceptionHandle(HttpServletResponse response, ApiExceptionImpl exception)
-            throws IOException {
-        response.setStatus(exception.getHttpStatus().value());
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-
-        Api<Object> apiResponse = Api.fail(exception);
-        ObjectMapper objectMapper = new ObjectMapper();
-        String jsonResponse = objectMapper.writeValueAsString(apiResponse);
-
-        response.getWriter().write(jsonResponse);
+            log.debug(entity.getEmail());
+            if (jwtUtils.validateToken(jwtToken, entity)) {
+                CustomUserDetail customUserDetail = new CustomUserDetail(entity);
+                UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                        new UsernamePasswordAuthenticationToken(
+                                customUserDetail, null, customUserDetail.getAuthorities());
+                usernamePasswordAuthenticationToken.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext()
+                        .setAuthentication(usernamePasswordAuthenticationToken);
+            } else {
+                SecurityContextHolder.getContext().setAuthentication(null);
+                return;
+            }
+            filterChain.doFilter(request, response);
+        }
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/filter/JwtRequestFilter.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/filter/JwtRequestFilter.java
@@ -1,6 +1,5 @@
 package org.ioteatime.meonghanyangserver.filter;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -12,15 +11,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.exception.*;
 import org.ioteatime.meonghanyangserver.common.type.AuthErrorType;
-import org.ioteatime.meonghanyangserver.common.type.CommonErrorType;
 import org.ioteatime.meonghanyangserver.common.utils.JwtUtils;
 import org.ioteatime.meonghanyangserver.groupmember.repository.GroupMemberRepository;
 import org.ioteatime.meonghanyangserver.member.domain.MemberEntity;
 import org.ioteatime.meonghanyangserver.member.dto.CustomUserDetail;
 import org.ioteatime.meonghanyangserver.member.repository.MemberRepository;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -56,7 +52,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
             if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
                 jwtToken = authorizationHeader.substring(7);
-                //access token 블랙리스트 확인
+                // access token 블랙리스트 확인
                 if (jwtUtils.blackListAccessToken(jwtToken)) {
                     throw new UnauthorizedException(AuthErrorType.HEADER_INVALID);
                 }
@@ -88,12 +84,14 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                 }
                 filterChain.doFilter(request, response);
             }
-        }catch (ApiExceptionImpl exception) {
+        } catch (ApiExceptionImpl exception) {
             exceptionHandle(response, exception);
         }
     }
-    //jwtRequest filter exception handle
-    private void exceptionHandle(HttpServletResponse response, ApiExceptionImpl exception) throws IOException {
+
+    // jwtRequest filter exception handle
+    private void exceptionHandle(HttpServletResponse response, ApiExceptionImpl exception)
+            throws IOException {
         response.setStatus(exception.getHttpStatus().value());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/org/ioteatime/meonghanyangserver/filter/JwtRequestFilter.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/filter/JwtRequestFilter.java
@@ -1,5 +1,6 @@
 package org.ioteatime.meonghanyangserver.filter;
 
+import com.amazonaws.services.kinesisvideo.model.NotAuthorizedException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -7,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.ioteatime.meonghanyangserver.common.exception.BadRequestException;
 import org.ioteatime.meonghanyangserver.common.exception.NotFoundException;
 import org.ioteatime.meonghanyangserver.common.exception.UnauthorizedException;
 import org.ioteatime.meonghanyangserver.common.type.AuthErrorType;
@@ -52,6 +54,9 @@ public class JwtRequestFilter extends OncePerRequestFilter {
             jwtToken = authorizationHeader.substring(7);
             jwtId = jwtUtils.getIdFromToken(jwtToken);
             log.debug("jwt : ", jwtToken);
+            if(jwtUtils.blackListAccessToken(jwtToken)){
+                throw new BadRequestException(AuthErrorType.HEADER_INVALID);
+            }
         } else {
             log.error("Authorization 헤더 누락 또는 토큰 형식 오류");
             throw new UnauthorizedException(AuthErrorType.HEADER_INVALID);

--- a/src/main/java/org/ioteatime/meonghanyangserver/filter/JwtRequestFilter.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/filter/JwtRequestFilter.java
@@ -1,6 +1,7 @@
 package org.ioteatime.meonghanyangserver.filter;
 
-import com.amazonaws.services.kinesisvideo.model.NotAuthorizedException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,16 +9,18 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.ioteatime.meonghanyangserver.common.exception.BadRequestException;
-import org.ioteatime.meonghanyangserver.common.exception.NotFoundException;
-import org.ioteatime.meonghanyangserver.common.exception.UnauthorizedException;
+import org.ioteatime.meonghanyangserver.common.api.Api;
+import org.ioteatime.meonghanyangserver.common.exception.*;
 import org.ioteatime.meonghanyangserver.common.type.AuthErrorType;
+import org.ioteatime.meonghanyangserver.common.type.CommonErrorType;
 import org.ioteatime.meonghanyangserver.common.utils.JwtUtils;
 import org.ioteatime.meonghanyangserver.groupmember.repository.GroupMemberRepository;
 import org.ioteatime.meonghanyangserver.member.domain.MemberEntity;
 import org.ioteatime.meonghanyangserver.member.dto.CustomUserDetail;
 import org.ioteatime.meonghanyangserver.member.repository.MemberRepository;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -36,52 +39,69 @@ public class JwtRequestFilter extends OncePerRequestFilter {
     protected void doFilterInternal(
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String uri = request.getRequestURI();
-        if (uri.contains("/open-api")
-                || uri.contains("/swagger-ui")
-                || uri.contains("/v3/api-docs")
-                || uri.contains("/static")) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        String jwtToken = null;
-        Long jwtId = null;
-
-        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            jwtToken = authorizationHeader.substring(7);
-            jwtId = jwtUtils.getIdFromToken(jwtToken);
-            log.debug("jwt : ", jwtToken);
-            if(jwtUtils.blackListAccessToken(jwtToken)){
-                throw new BadRequestException(AuthErrorType.HEADER_INVALID);
-            }
-        } else {
-            log.error("Authorization 헤더 누락 또는 토큰 형식 오류");
-            throw new UnauthorizedException(AuthErrorType.HEADER_INVALID);
-        }
-        if (jwtId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            MemberEntity entity =
-                    memberRepository
-                            .findById(jwtId)
-                            .orElseThrow(() -> new NotFoundException(AuthErrorType.NOT_FOUND));
-
-            log.debug(entity.getEmail());
-            if (jwtUtils.validateToken(jwtToken, entity)) {
-                CustomUserDetail customUserDetail = new CustomUserDetail(entity);
-                UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-                        new UsernamePasswordAuthenticationToken(
-                                customUserDetail, null, customUserDetail.getAuthorities());
-                usernamePasswordAuthenticationToken.setDetails(
-                        new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext()
-                        .setAuthentication(usernamePasswordAuthenticationToken);
-            } else {
-                SecurityContextHolder.getContext().setAuthentication(null);
+        try {
+            String uri = request.getRequestURI();
+            if (uri.contains("/open-api")
+                    || uri.contains("/swagger-ui")
+                    || uri.contains("/v3/api-docs")
+                    || uri.contains("/static")) {
+                filterChain.doFilter(request, response);
                 return;
             }
-            filterChain.doFilter(request, response);
+
+            String jwtToken = null;
+            Long jwtId = null;
+
+            String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+            if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+                jwtToken = authorizationHeader.substring(7);
+                //access token 블랙리스트 확인
+                if (jwtUtils.blackListAccessToken(jwtToken)) {
+                    throw new UnauthorizedException(AuthErrorType.HEADER_INVALID);
+                }
+                jwtId = jwtUtils.getIdFromToken(jwtToken);
+                log.debug("jwt : ", jwtToken);
+            } else {
+                log.error("Authorization 헤더 누락 또는 토큰 형식 오류");
+                throw new UnauthorizedException(AuthErrorType.HEADER_INVALID);
+            }
+            if (jwtId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                MemberEntity entity =
+                        memberRepository
+                                .findById(jwtId)
+                                .orElseThrow(() -> new NotFoundException(AuthErrorType.NOT_FOUND));
+
+                log.debug(entity.getEmail());
+                if (jwtUtils.validateToken(jwtToken, entity)) {
+                    CustomUserDetail customUserDetail = new CustomUserDetail(entity);
+                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                            new UsernamePasswordAuthenticationToken(
+                                    customUserDetail, null, customUserDetail.getAuthorities());
+                    usernamePasswordAuthenticationToken.setDetails(
+                            new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext()
+                            .setAuthentication(usernamePasswordAuthenticationToken);
+                } else {
+                    SecurityContextHolder.getContext().setAuthentication(null);
+                    return;
+                }
+                filterChain.doFilter(request, response);
+            }
+        }catch (ApiExceptionImpl exception) {
+            exceptionHandle(response, exception);
         }
+    }
+    //jwtRequest filter exception handle
+    private void exceptionHandle(HttpServletResponse response, ApiExceptionImpl exception) throws IOException {
+        response.setStatus(exception.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Api<Object> apiResponse = Api.fail(exception);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+
+        response.getWriter().write(jsonResponse);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/handler/CustomLogoutHandler.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/handler/CustomLogoutHandler.java
@@ -1,0 +1,54 @@
+package org.ioteatime.meonghanyangserver.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ioteatime.meonghanyangserver.common.utils.JwtUtils;
+import org.ioteatime.meonghanyangserver.redis.AccessToken;
+import org.ioteatime.meonghanyangserver.redis.AccessTokenRepository;
+import org.ioteatime.meonghanyangserver.redis.RefreshTokenRepository;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomLogoutHandler implements LogoutHandler {
+    private final JwtUtils jwtUtils;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final AccessTokenRepository accessTokenRepository;
+
+    @Override
+    public void logout(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication) {
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        // token 없을 시
+        if (authorizationHeader.isEmpty()) {
+            return;
+        }
+        String accessToken = authorizationHeader.substring(7);
+
+        // access token이 블랙리스트에 있을 경우
+        if (accessTokenRepository.existsByAccessToken(accessToken)) {
+            return;
+        }
+
+        Long memberId = jwtUtils.getIdFromToken(accessToken);
+        log.debug("jwt : ", accessToken);
+        refreshTokenRepository.deleteByMemberId(memberId);
+        Date date = jwtUtils.getExpirationDateFromToken(accessToken);
+        // access token의 남은 시간
+        long ttl = (date.getTime() - System.currentTimeMillis()) / 1000;
+
+        AccessToken accessTokenEntity =
+                AccessToken.builder().accessToken(accessToken).ttl(ttl).build();
+        // access token 블랙리스트
+        accessTokenRepository.save(accessTokenEntity);
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/handler/CustomLogoutSuccessHandler.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/handler/CustomLogoutSuccessHandler.java
@@ -1,0 +1,30 @@
+package org.ioteatime.meonghanyangserver.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.ioteatime.meonghanyangserver.common.api.Api;
+import org.ioteatime.meonghanyangserver.common.type.AuthSuccessType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
+    @Override
+    public void onLogoutSuccess(
+            HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Api<Object> apiResponse = Api.success(AuthSuccessType.SIGN_OUT);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/handler/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package org.ioteatime.meonghanyangserver.handler;
 
-import io.jsonwebtoken.io.IOException;
-import jakarta.servlet.ServletException;
 import jakarta.validation.UnexpectedTypeException;
 import lombok.extern.slf4j.Slf4j;
 import org.ioteatime.meonghanyangserver.common.api.Api;
@@ -38,5 +36,4 @@ public class GlobalExceptionHandler {
         log.info("", exception);
         return ResponseEntity.status(exception.getHttpStatus()).body(Api.fail(exception));
     }
-
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/handler/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package org.ioteatime.meonghanyangserver.handler;
 
+import io.jsonwebtoken.io.IOException;
+import jakarta.servlet.ServletException;
 import jakarta.validation.UnexpectedTypeException;
 import lombok.extern.slf4j.Slf4j;
 import org.ioteatime.meonghanyangserver.common.api.Api;
@@ -36,4 +38,5 @@ public class GlobalExceptionHandler {
         log.info("", exception);
         return ResponseEntity.status(exception.getHttpStatus()).body(Api.fail(exception));
     }
+
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberApi.java
@@ -29,5 +29,5 @@ public interface MemberApi {
     Api<RefreshResponse> refreshToken(@RequestHeader("Authorization") String authorizationHeader);
 
     @Operation(summary = "로그아웃을 진행합니다.", description = "담당자: 최민석")
-    Api<?> logout(@LoginMember Long memberId);
+    Api<?> logout(@LoginMember Long memberId, @RequestHeader("Authorization") String accessToken);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberApi.java
@@ -29,5 +29,5 @@ public interface MemberApi {
     Api<RefreshResponse> refreshToken(@RequestHeader("Authorization") String authorizationHeader);
 
     @Operation(summary = "로그아웃을 진행합니다.", description = "담당자: 최민석")
-    Api<?> logout(@LoginMember Long memberId, @RequestHeader("Authorization") String accessToken);
+    Api<?> logout();
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberApi.java
@@ -27,4 +27,7 @@ public interface MemberApi {
 
     @Operation(summary = "Access 토큰을 다시 생성합니다.", description = "담당자: 서유진")
     Api<RefreshResponse> refreshToken(@RequestHeader("Authorization") String authorizationHeader);
+
+    @Operation(summary = "로그아웃을 진행합니다.", description = "담당자: 최민석")
+    Api<?> logout(@LoginMember Long memberId);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberController.java
@@ -10,7 +10,6 @@ import org.ioteatime.meonghanyangserver.member.dto.request.ChangePasswordRequest
 import org.ioteatime.meonghanyangserver.member.dto.response.MemberDetailResponse;
 import org.ioteatime.meonghanyangserver.member.service.MemberService;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.security.core.Authentication;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,8 +44,9 @@ public class MemberController implements MemberApi {
     }
 
     @PostMapping("/sign-out")
-    public Api<?> logout(@LoginMember Long memberId,@RequestHeader("Authorization") String accessToken) {
-        memberService.logout(memberId,accessToken);
+    public Api<?> logout(
+            @LoginMember Long memberId, @RequestHeader("Authorization") String accessToken) {
+        memberService.logout(memberId, accessToken);
         return Api.success(AuthSuccessType.SIGN_OUT);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberController.java
@@ -44,9 +44,7 @@ public class MemberController implements MemberApi {
     }
 
     @PostMapping("/sign-out")
-    public Api<?> logout(
-            @LoginMember Long memberId, @RequestHeader("Authorization") String accessToken) {
-        memberService.logout(memberId, accessToken);
+    public Api<?> logout() {
         return Api.success(AuthSuccessType.SIGN_OUT);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import org.ioteatime.meonghanyangserver.member.dto.request.ChangePasswordRequest
 import org.ioteatime.meonghanyangserver.member.dto.response.MemberDetailResponse;
 import org.ioteatime.meonghanyangserver.member.service.MemberService;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.Authentication;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,9 +44,9 @@ public class MemberController implements MemberApi {
         return Api.success(AuthSuccessType.REISSUE_ACCESS_TOKEN, refreshResponse);
     }
 
-    @DeleteMapping("/logout")
-    public Api<?> logout(@LoginMember Long memberId) {
-        memberService.logout(memberId);
-        return null;
+    @PostMapping("/sign-out")
+    public Api<?> logout(@LoginMember Long memberId,@RequestHeader("Authorization") String accessToken) {
+        memberService.logout(memberId,accessToken);
+        return Api.success(AuthSuccessType.SIGN_OUT);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberController.java
@@ -42,4 +42,10 @@ public class MemberController implements MemberApi {
         RefreshResponse refreshResponse = memberService.reissueAccessToken(authorizationHeader);
         return Api.success(AuthSuccessType.REISSUE_ACCESS_TOKEN, refreshResponse);
     }
+
+    @DeleteMapping("/logout")
+    public Api<?> logout(@LoginMember Long memberId) {
+        memberService.logout(memberId);
+        return null;
+    }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
@@ -156,9 +156,9 @@ public class MemberService {
     public void logout(Long memberId, String accessToken) {
         refreshTokenRepository.deleteByMemberId(memberId);
         accessToken = accessToken.substring(7);
-        Date data = jwtUtils.getExpirationDateFromToken(accessToken);
+        Date date = jwtUtils.getExpirationDateFromToken(accessToken);
         // access token의 남은 시간
-        long ttl = (data.getTime() - System.currentTimeMillis()) / 1000;
+        long ttl = (date.getTime() - System.currentTimeMillis()) / 1000;
 
         AccessToken accessTokenEntity =
                 AccessToken.builder().accessToken(accessToken).ttl(ttl).build();

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
@@ -85,4 +85,6 @@ public class MemberService {
 
         return AuthResponseMapper.from(newAccessToken);
     }
+
+    public void logout(Long memberId) {}
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package org.ioteatime.meonghanyangserver.member.service;
 
-import java.util.Date;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.auth.dto.reponse.RefreshResponse;
@@ -23,7 +22,6 @@ import org.ioteatime.meonghanyangserver.member.dto.request.ChangePasswordRequest
 import org.ioteatime.meonghanyangserver.member.dto.response.MemberDetailResponse;
 import org.ioteatime.meonghanyangserver.member.mapper.MemberResponseMapper;
 import org.ioteatime.meonghanyangserver.member.repository.MemberRepository;
-import org.ioteatime.meonghanyangserver.redis.AccessToken;
 import org.ioteatime.meonghanyangserver.redis.AccessTokenRepository;
 import org.ioteatime.meonghanyangserver.redis.RefreshToken;
 import org.ioteatime.meonghanyangserver.redis.RefreshTokenRepository;

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
@@ -151,18 +151,4 @@ public class MemberService {
 
         return AuthResponseMapper.from(newAccessToken);
     }
-
-    @Transactional
-    public void logout(Long memberId, String accessToken) {
-        refreshTokenRepository.deleteByMemberId(memberId);
-        accessToken = accessToken.substring(7);
-        Date date = jwtUtils.getExpirationDateFromToken(accessToken);
-        // access token의 남은 시간
-        long ttl = (date.getTime() - System.currentTimeMillis()) / 1000;
-
-        AccessToken accessTokenEntity =
-                AccessToken.builder().accessToken(accessToken).ttl(ttl).build();
-        // access token 블랙리스트
-        accessTokenRepository.save(accessTokenEntity);
-    }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
@@ -91,18 +91,16 @@ public class MemberService {
     }
 
     @Transactional
-    public void logout(Long memberId,String accessToken) {
+    public void logout(Long memberId, String accessToken) {
         refreshTokenRepository.deleteByMemberId(memberId);
         accessToken = accessToken.substring(7);
         Date data = jwtUtils.getExpirationDateFromToken(accessToken);
-        //access token의 남은 시간
+        // access token의 남은 시간
         long ttl = (data.getTime() - System.currentTimeMillis()) / 1000;
 
-        AccessToken accessTokenEntity = AccessToken.builder()
-                .accessToken(accessToken)
-                .ttl(ttl).build();
-        //access token 블랙리스트
+        AccessToken accessTokenEntity =
+                AccessToken.builder().accessToken(accessToken).ttl(ttl).build();
+        // access token 블랙리스트
         accessTokenRepository.save(accessTokenEntity);
-
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/redis/AccessToken.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/redis/AccessToken.java
@@ -13,12 +13,9 @@ import org.springframework.data.redis.core.index.Indexed;
 @Builder
 @RedisHash(value = "accessToken")
 public class AccessToken {
-    @Id
-    private Long id;
+    @Id private Long id;
 
-    @Indexed
-    private String accessToken;
+    @Indexed private String accessToken;
 
-    @TimeToLive
-    private long ttl;
+    @TimeToLive private long ttl;
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/redis/AccessToken.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/redis/AccessToken.java
@@ -5,16 +5,20 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @AllArgsConstructor
 @Builder
-@RedisHash(value = "refreshToken", timeToLive = 60 * 60 * 24 * 30)
-public class RefreshToken {
-    @Id private Long id;
+@RedisHash(value = "accessToken")
+public class AccessToken {
+    @Id
+    private Long id;
 
-    @Indexed private String refreshToken;
+    @Indexed
+    private String accessToken;
 
-    private Long memberId;
+    @TimeToLive
+    private long ttl;
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/redis/AccessTokenRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/redis/AccessTokenRepository.java
@@ -1,0 +1,7 @@
+package org.ioteatime.meonghanyangserver.redis;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface AccessTokenRepository extends CrudRepository<AccessToken, String> {
+    boolean existsByAccessToken(String accessToken);
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/redis/RefreshToken.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/redis/RefreshToken.java
@@ -15,4 +15,6 @@ public class RefreshToken {
     @Id private Long id;
 
     @Indexed private String refreshToken;
+
+    @Indexed private Long memberId;
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/redis/RefreshTokenRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/redis/RefreshTokenRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/redis/RefreshTokenRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/redis/RefreshTokenRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
     void deleteByMemberId(Long memberId);
 }


### PR DESCRIPTION
### 📋 상세 설명
- 로그아웃 시 refresh token의 값을 redis에서 찾기 위해 member id를 같이 저장했습니다.
- 로그아웃 요청 시 refresh token을 제거한 후 access token을 redis에 access token의 남은 기간동안 저장을 하여 블랙리스트 관리를 하였습니다.
- jwt request filter는 RestControllerAdvice의 적용범위 밖에 있기 때문에 저희가 만든 global exception handler가 적용이 되지 않았습니다. 그래서 jwt request filter 내부에 exception handler를 만들어 적용했습니다.

### 📸 스크린샷
![스크린샷 2024-11-22 오후 3 35 35](https://github.com/user-attachments/assets/1ca1ee58-002f-4073-97a9-2e940ce40d14)
access token 만료 및 블랙리스트 적용시
![스크린샷 2024-11-22 오후 3 52 49](https://github.com/user-attachments/assets/13492cfa-d5ab-453b-935d-ee7385bb51dc)
