### PR TITLE
feat: 닉네임과 그룹 이름 함께 변경 가능한 API 구현

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthSuccessType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthSuccessType.java
@@ -9,7 +9,9 @@ public enum AuthSuccessType implements SuccessTypeCode {
     GET_USER_DETAIL(200, "OK", "회원 단건 조회에 성공하였습니다."),
     DELETE_USER(200, "OK", "회원 삭제에 성공하였습니다."),
     UPDATE_PASSWORD(200, "OK", "비밀번호 수정에 성공하였습니다."),
-    VERIFY_EMAIL_CODE(200, "OK", "이메일 인증 코드 검증에 성공하였습니다.");
+    VERIFY_EMAIL_CODE(200, "OK", "이메일 인증 코드 검증에 성공하였습니다."),
+    UPDATE_NICKNAME(200, "OK", "닉네임 수정에 성공하였습니다."),
+    UPDATE_NICKNAME_AND_GROUP_NAME(200, "OK", "닉네임과 그룹 이름 변경에 성공하였습니다.");
 
     private final Integer code;
     private final String message;

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/GroupSuccessType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/GroupSuccessType.java
@@ -8,7 +8,8 @@ public enum GroupSuccessType implements SuccessTypeCode {
     GET_GROUP_TOTAL_INFO(200, "OK", "그룹 통합 데이터 조회에 성공하였습니다."),
     DELETE_GROUP_MEMBER(200, "OK", "그룹에서 참여자 제외를 성공하였습니다."),
     JOIN_GROUP_MEMBER(201, "CREATE", "그룹에 참여자 등록을 성공하였습니다"),
-    GET_GROUP_MEMBER_INFO_LIST(200, "OK", "그룹 참여자 목록 데이터 조회에 성공하였습니다.");
+    GET_GROUP_MEMBER_INFO_LIST(200, "OK", "그룹 참여자 목록 데이터 조회에 성공하였습니다."),
+    UPDATE_GROUP_NAME(200, "OK", "그룹 이름 변경에 성공하였습니다.");
 
     private final Integer code;
     private final String message;

--- a/src/main/java/org/ioteatime/meonghanyangserver/group/domain/GroupEntity.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/group/domain/GroupEntity.java
@@ -37,4 +37,9 @@ public class GroupEntity {
 
     @OneToMany(mappedBy = "group")
     private List<CctvEntity> cctvEntities;
+
+    public GroupEntity updateGroupName(String groupName) {
+        this.groupName = groupName;
+        return this;
+    }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/group/dto/response/UpdateNicknameAndGroupNameResponse.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/group/dto/response/UpdateNicknameAndGroupNameResponse.java
@@ -1,0 +1,10 @@
+package org.ioteatime.meonghanyangserver.group.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "회원 닉네임과 소속된 그룹 이름 변경 응답")
+public record UpdateNicknameAndGroupNameResponse(
+        @Schema(description = "수정된 닉네임", example = "new-meonghaynag") String nickname,
+        @Schema(description = "수정된 그룹 이름", example = "new-group-name") String groupName) {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/group/mapper/GroupResponseMapper.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/group/mapper/GroupResponseMapper.java
@@ -6,6 +6,7 @@ import org.ioteatime.meonghanyangserver.cctv.mapper.CctvResponseMapper;
 import org.ioteatime.meonghanyangserver.group.domain.GroupEntity;
 import org.ioteatime.meonghanyangserver.group.dto.response.CreateGroupResponse;
 import org.ioteatime.meonghanyangserver.group.dto.response.GroupTotalResponse;
+import org.ioteatime.meonghanyangserver.group.dto.response.UpdateNicknameAndGroupNameResponse;
 import org.ioteatime.meonghanyangserver.groupmember.dto.response.GroupMemberInfoResponse;
 import org.ioteatime.meonghanyangserver.groupmember.mapper.GroupMemberResponseMapper;
 
@@ -30,5 +31,9 @@ public class GroupResponseMapper {
                 groupEntity.getCreatedAt(),
                 deviceInfoResponseList,
                 cctvInfoResponseList);
+    }
+
+    public static UpdateNicknameAndGroupNameResponse from(String nickname, String groupName) {
+        return new UpdateNicknameAndGroupNameResponse(nickname, groupName);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberApi.java
@@ -2,11 +2,12 @@ package org.ioteatime.meonghanyangserver.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.ioteatime.meonghanyangserver.auth.dto.reponse.RefreshResponse;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
+import org.ioteatime.meonghanyangserver.group.dto.response.UpdateNicknameAndGroupNameResponse;
 import org.ioteatime.meonghanyangserver.member.dto.request.ChangePasswordRequest;
+import org.ioteatime.meonghanyangserver.member.dto.request.UpdateNicknameAndGroupNameRequest;
 import org.ioteatime.meonghanyangserver.member.dto.response.MemberDetailResponse;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,8 +24,14 @@ public interface MemberApi {
 
     @Operation(summary = "회원의 비밀번호를 변경합니다.", description = "담당자: 임지인")
     Api<Object> changeMemberPassword(
-            @LoginMember Long memberId, @RequestBody @Valid ChangePasswordRequest request);
+            @LoginMember Long memberId, @RequestBody ChangePasswordRequest request);
 
     @Operation(summary = "Access 토큰을 다시 생성합니다.", description = "담당자: 서유진")
     Api<RefreshResponse> refreshToken(@RequestHeader("Authorization") String authorizationHeader);
+
+    @Operation(
+            summary = "회원 닉네임과 회원이 소속된 그룹명을 변경합니다.",
+            description = "담당자: 양원채\n\n닉네임 또는 그룹명을 갱신할 수 있으며, 한꺼번에 갱신도 가능합니다. 응답으로는 변경된 사항만 응답합니다.")
+    Api<UpdateNicknameAndGroupNameResponse> updateNicknameAndGroupName(
+            @LoginMember Long memberId, @RequestBody UpdateNicknameAndGroupNameRequest request);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberApi.java
@@ -31,7 +31,8 @@ public interface MemberApi {
 
     @Operation(
             summary = "회원 닉네임과 회원이 소속된 그룹명을 변경합니다.",
-            description = "담당자: 양원채\n\n닉네임 또는 그룹명을 갱신할 수 있으며, 한꺼번에 갱신도 가능합니다. 응답으로는 변경된 사항만 응답합니다.")
+            description =
+                    "담당자: 양원채\n\n닉네임 또는 그룹명을 갱신할 수 있으며, 한꺼번에 갱신도 가능합니다.\n\n갱신하고 싶지 않은 필드는 아예 적지 않거나 null로 담아 요청하시면 됩니다. 응답으로는 변경된 사항만 응답합니다.")
     Api<UpdateNicknameAndGroupNameResponse> updateNicknameAndGroupName(
             @LoginMember Long memberId, @RequestBody UpdateNicknameAndGroupNameRequest request);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberController.java
@@ -5,8 +5,11 @@ import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.auth.dto.reponse.RefreshResponse;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.type.AuthSuccessType;
+import org.ioteatime.meonghanyangserver.common.type.GroupSuccessType;
 import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
+import org.ioteatime.meonghanyangserver.group.dto.response.UpdateNicknameAndGroupNameResponse;
 import org.ioteatime.meonghanyangserver.member.dto.request.ChangePasswordRequest;
+import org.ioteatime.meonghanyangserver.member.dto.request.UpdateNicknameAndGroupNameRequest;
 import org.ioteatime.meonghanyangserver.member.dto.response.MemberDetailResponse;
 import org.ioteatime.meonghanyangserver.member.service.MemberService;
 import org.springframework.web.bind.annotation.*;
@@ -41,5 +44,19 @@ public class MemberController implements MemberApi {
             @RequestHeader("Authorization") String authorizationHeader) {
         RefreshResponse refreshResponse = memberService.reissueAccessToken(authorizationHeader);
         return Api.success(AuthSuccessType.REISSUE_ACCESS_TOKEN, refreshResponse);
+    }
+
+    @PatchMapping("/nickname-groupname")
+    public Api<UpdateNicknameAndGroupNameResponse> updateNicknameAndGroupName(
+            @LoginMember Long memberId, @RequestBody UpdateNicknameAndGroupNameRequest request) {
+        UpdateNicknameAndGroupNameResponse response =
+                memberService.updateNicknameAndGroupName(memberId, request);
+        if (response.groupName() == null) {
+            return Api.success(AuthSuccessType.UPDATE_NICKNAME, response);
+        } else if (response.nickname() == null) {
+            return Api.success(GroupSuccessType.UPDATE_GROUP_NAME, response);
+        } else {
+            return Api.success(AuthSuccessType.UPDATE_NICKNAME_AND_GROUP_NAME, response);
+        }
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/domain/MemberEntity.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/domain/MemberEntity.java
@@ -67,4 +67,9 @@ public class MemberEntity {
         this.updatedAt = LocalDateTime.now();
         return this;
     }
+
+    public MemberEntity updateNickname(String nickname) {
+        this.nickname = nickname;
+        return this;
+    }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/dto/request/UpdateNicknameAndGroupNameRequest.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/dto/request/UpdateNicknameAndGroupNameRequest.java
@@ -1,0 +1,8 @@
+package org.ioteatime.meonghanyangserver.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 닉네임과 소속된 그룹 이름 변경 요청")
+public record UpdateNicknameAndGroupNameRequest(
+        @Schema(description = "수정할 닉네임", example = "new-meonghaynag") String nickname,
+        @Schema(description = "수정할 그룹 이름", example = "new-group-name") String groupName) {}


### PR DESCRIPTION
### 📋 상세 설명
- 닉네임과 그룹 이름을 함께 변경이 가능한 API를 구현했습니다.
- UI에서 확인 버튼이 하나라, 책임 분리 문제를 조금 겪더라도 API는 한 개로 두는 게 프론트 작업에 도움이 될 것 같다고 판단하였습니다.
<img width="248" alt="Screenshot 2024-11-22 at 18 45 25" src="https://github.com/user-attachments/assets/f6a17a79-9115-489c-a615-9241d0bc3683">

### 📸 스크린샷
- 닉네임만 변경한 경우 (nickname 필드만 채워서 보내야 함)
<img width="374" alt="Screenshot 2024-11-22 at 18 39 25" src="https://github.com/user-attachments/assets/c050d4a6-8967-4b0d-9c66-124d24c44ddc">
<img width="839" alt="Screenshot 2024-11-22 at 18 42 09" src="https://github.com/user-attachments/assets/ec94380c-060d-4083-b824-c201bd168e6e">
<img width="373" alt="Screenshot 2024-11-22 at 18 39 48" src="https://github.com/user-attachments/assets/688e4e35-2bb9-4038-b722-d794d812a935">

- 그룹 이름만 변경한 경우 (groupName 필드만 채워서 보내야 함)
<img width="269" alt="Screenshot 2024-11-22 at 18 42 31" src="https://github.com/user-attachments/assets/fb633526-2d77-4b40-bac7-6e7e5c1159c0">
<img width="831" alt="Screenshot 2024-11-22 at 18 42 47" src="https://github.com/user-attachments/assets/f2b732c8-868c-41a5-9891-8f5182db9540">
<img width="302" alt="Screenshot 2024-11-22 at 18 42 52" src="https://github.com/user-attachments/assets/d61c79e1-5ec3-43a3-b2af-2d04b2979ac5">

- 닉네임과 그룹 이름을 모두 변경한 경우
<img width="832" alt="Screenshot 2024-11-22 at 18 43 15" src="https://github.com/user-attachments/assets/264a205d-0b9c-4e5c-90c1-cfd473645ad9">
<img width="265" alt="Screenshot 2024-11-22 at 18 43 20" src="https://github.com/user-attachments/assets/c91cf40f-3256-41be-88cb-2e49c0f54447">
<img width="412" alt="Screenshot 2024-11-22 at 18 43 24" src="https://github.com/user-attachments/assets/56b5f045-4035-43d7-ae43-dbd6dd1f06a9">