### PR TITLE
feat: 그룹 통합 정보 조회에서 참여자 정보 제거

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/group/dto/response/GroupTotalResponse.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/group/dto/response/GroupTotalResponse.java
@@ -6,12 +6,11 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.ioteatime.meonghanyangserver.cctv.dto.response.CctvInfoResponse;
-import org.ioteatime.meonghanyangserver.groupmember.dto.response.GroupMemberInfoResponse;
 
 @Schema(description = "그룹 통합 정보 응답")
 public record GroupTotalResponse(
-        @NotNull Long groupId,
-        @NotBlank String groupName,
-        @NotNull LocalDateTime createdAt,
-        List<GroupMemberInfoResponse> member,
-        List<CctvInfoResponse> cctv) {}
+        @NotNull @Schema(description = "그룹 ID", example = "1") Long groupId,
+        @NotBlank @Schema(description = "그룹 이름", example = "멍하냥 그룹") String groupName,
+        @NotNull @Schema(description = "그룹 생성 시간", example = "2024-10-10 15:00")
+                LocalDateTime createdAt,
+        @Schema(description = "그룹의 CCTV 정보 목록") List<CctvInfoResponse> cctv) {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/group/mapper/GroupResponseMapper.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/group/mapper/GroupResponseMapper.java
@@ -7,8 +7,6 @@ import org.ioteatime.meonghanyangserver.group.domain.GroupEntity;
 import org.ioteatime.meonghanyangserver.group.dto.response.CreateGroupResponse;
 import org.ioteatime.meonghanyangserver.group.dto.response.GroupTotalResponse;
 import org.ioteatime.meonghanyangserver.group.dto.response.UpdateNicknameAndGroupNameResponse;
-import org.ioteatime.meonghanyangserver.groupmember.dto.response.GroupMemberInfoResponse;
-import org.ioteatime.meonghanyangserver.groupmember.mapper.GroupMemberResponseMapper;
 
 public class GroupResponseMapper {
     public static CreateGroupResponse from(GroupEntity groupEntity) {
@@ -17,11 +15,6 @@ public class GroupResponseMapper {
     }
 
     public static GroupTotalResponse fromGroupTotal(GroupEntity groupEntity) {
-        List<GroupMemberInfoResponse> deviceInfoResponseList =
-                groupEntity.getGroupMemberEntities().stream()
-                        .map(GroupMemberResponseMapper::from)
-                        .toList();
-
         List<CctvInfoResponse> cctvInfoResponseList =
                 groupEntity.getCctvEntities().stream().map(CctvResponseMapper::from).toList();
 
@@ -29,7 +22,6 @@ public class GroupResponseMapper {
                 groupEntity.getId(),
                 groupEntity.getGroupName(),
                 groupEntity.getCreatedAt(),
-                deviceInfoResponseList,
                 cctvInfoResponseList);
     }
 


### PR DESCRIPTION
### 📋 상세 설명
- 참여자 정보는 방장만 조회가 가능하기 때문에 그룹 통합 정보 조회에서 참여자 정보만 제거합니다.

### 📸 스크린샷
<img width="841" alt="Screenshot 2024-11-23 at 14 33 33" src="https://github.com/user-attachments/assets/f97be174-1715-4764-a5d3-c8b8b3c0687c">