### PR TITLE
feat: 로그인 성공 시 그룹 가입 여부와 역할 응답

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/dto/db/LoginWithMemberInfo.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/dto/db/LoginWithMemberInfo.java
@@ -1,0 +1,10 @@
+package org.ioteatime.meonghanyangserver.auth.dto.db;
+
+import org.ioteatime.meonghanyangserver.groupmember.doamin.enums.GroupMemberRole;
+
+public record LoginWithMemberInfo(
+        Long memberId,
+        String nickname,
+        String password,
+        boolean isGroupMember,
+        GroupMemberRole role) {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/dto/reponse/LoginResponse.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/dto/reponse/LoginResponse.java
@@ -1,21 +1,34 @@
 package org.ioteatime.meonghanyangserver.auth.dto.reponse;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+import org.ioteatime.meonghanyangserver.groupmember.doamin.enums.GroupMemberRole;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record LoginResponse(
         @NotNull @Schema(description = "회원 ID", example = "1") Long memberId,
         @NotBlank @Schema(description = "회원 AccessToken", example = "Bearer abcd...")
                 String accessToken,
         @NotBlank @Schema(description = "회원 RefreshToken", example = "Bearer abcd...")
-                String refreshToken) {
+                String refreshToken,
+        @NotNull @Schema(description = "회원이 가입한 그룹이 있는지 여부", example = "true")
+                Boolean isGroupMember,
+        @Schema(description = "회원의 그룹 역할", example = "MASTER") GroupMemberRole role) {
 
     @Builder
-    public LoginResponse(Long memberId, String accessToken, String refreshToken) {
+    public LoginResponse(
+            Long memberId,
+            String accessToken,
+            String refreshToken,
+            Boolean isGroupMember,
+            GroupMemberRole role) {
         this.memberId = memberId;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
+        this.isGroupMember = isGroupMember;
+        this.role = role;
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/mapper/AuthResponseMapper.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/mapper/AuthResponseMapper.java
@@ -1,5 +1,6 @@
 package org.ioteatime.meonghanyangserver.auth.mapper;
 
+import org.ioteatime.meonghanyangserver.auth.dto.db.LoginWithMemberInfo;
 import org.ioteatime.meonghanyangserver.auth.dto.reponse.LoginResponse;
 import org.ioteatime.meonghanyangserver.auth.dto.reponse.RefreshResponse;
 import org.ioteatime.meonghanyangserver.member.dto.response.MemberSimpleResponse;
@@ -9,11 +10,14 @@ public class AuthResponseMapper {
         return new MemberSimpleResponse(id, email);
     }
 
-    public static LoginResponse from(Long id, String accessToken, String refreshToken) {
+    public static LoginResponse from(
+            LoginWithMemberInfo memberInfo, String accessToken, String refreshToken) {
         return LoginResponse.builder()
-                .memberId(id)
+                .memberId(memberInfo.memberId())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .isGroupMember(memberInfo.isGroupMember())
+                .role(memberInfo.role())
                 .build();
     }
 

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/utils/JwtUtils.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/utils/JwtUtils.java
@@ -28,14 +28,14 @@ public class JwtUtils {
         this.key = Keys.hmacShaKeyFor(decodedKey);
     }
 
-    public String generateAccessToken(MemberEntity memberEntity) {
+    public String generateAccessToken(String nickname, Long memberId) {
         Date nowDate = new Date();
         Date expiration = new Date(nowDate.getTime() + Duration.ofHours(2).toMillis());
         String jwtToken =
                 Jwts.builder()
-                        .claim("name", memberEntity.getNickname())
+                        .claim("name", nickname)
                         .claim("sub", "meong-ha-nyang")
-                        .claim("jti", String.valueOf(memberEntity.getId()))
+                        .claim("jti", String.valueOf(memberId))
                         .claim("iat", nowDate)
                         .claim("exp", expiration)
                         .signWith(key)
@@ -44,14 +44,14 @@ public class JwtUtils {
         return jwtToken;
     }
 
-    public String generateRefreshToken(MemberEntity memberEntity) {
+    public String generateRefreshToken(String nickname, Long memberId) {
         Date nowDate = new Date();
         Date expiration = new Date(nowDate.getTime() + Duration.ofDays(30).toMillis());
         String jwtToken =
                 Jwts.builder()
-                        .claim("name", memberEntity.getNickname())
+                        .claim("name", nickname)
                         .claim("sub", "meong-ha-nyang")
-                        .claim("jti", String.valueOf(memberEntity.getId()))
+                        .claim("jti", String.valueOf(memberId))
                         .claim("iat", nowDate)
                         .claim("exp", expiration)
                         .signWith(key)

--- a/src/main/java/org/ioteatime/meonghanyangserver/groupmember/controller/GroupMemberApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/groupmember/controller/GroupMemberApi.java
@@ -24,7 +24,7 @@ public interface GroupMemberApi {
             @PathVariable Long groupId,
             @PathVariable Long groupMemberId);
 
-    @Operation(summary = "그룹에서 참여자를 제외합니다.", description = "담당자: 최민석")
+    @Operation(summary = "그룹에서 참여자가 스스로 퇴장합니다.", description = "담당자: 최민석")
     public Api<?> deleteGroupMember(@LoginMember Long memberId, @PathVariable Long groupId);
 
     @Operation(summary = "그룹 참여자들의 정보를 조회합니다.", description = "담당자: 최민석")

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/repository/MemberRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package org.ioteatime.meonghanyangserver.member.repository;
 
 import java.util.Optional;
+import org.ioteatime.meonghanyangserver.auth.dto.db.LoginWithMemberInfo;
 import org.ioteatime.meonghanyangserver.member.domain.MemberEntity;
 
 public interface MemberRepository {
@@ -13,4 +14,6 @@ public interface MemberRepository {
     MemberEntity save(MemberEntity MemberEntity);
 
     Optional<MemberEntity> updateFcmTokenById(Long memberId, String token);
+
+    Optional<LoginWithMemberInfo> findGroupMemberInfoByEmail(String email);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/repository/MemberRepositoryImpl.java
@@ -1,10 +1,13 @@
 package org.ioteatime.meonghanyangserver.member.repository;
 
+import static org.ioteatime.meonghanyangserver.groupmember.doamin.QGroupMemberEntity.groupMemberEntity;
 import static org.ioteatime.meonghanyangserver.member.domain.QMemberEntity.memberEntity;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.ioteatime.meonghanyangserver.auth.dto.db.LoginWithMemberInfo;
 import org.ioteatime.meonghanyangserver.member.domain.MemberEntity;
 import org.springframework.stereotype.Repository;
 
@@ -37,5 +40,24 @@ public class MemberRepositoryImpl implements MemberRepository {
     @Override
     public Optional<MemberEntity> updateFcmTokenById(Long memberId, String token) {
         return jpaMemberRepository.findById(memberId).map(entity -> entity.updateFcmToken(token));
+    }
+
+    @Override
+    public Optional<LoginWithMemberInfo> findGroupMemberInfoByEmail(String email) {
+        return Optional.ofNullable(
+                queryFactory
+                        .select(
+                                Projections.constructor(
+                                        LoginWithMemberInfo.class,
+                                        memberEntity.id.as("memberId"),
+                                        memberEntity.nickname.as("nickname"),
+                                        memberEntity.password.as("password"),
+                                        groupMemberEntity.id.isNotNull().as("isGroupMember"),
+                                        groupMemberEntity.role.as("role")))
+                        .from(memberEntity)
+                        .leftJoin(groupMemberEntity)
+                        .on(groupMemberEntity.member.eq(memberEntity))
+                        .where(memberEntity.email.eq(email))
+                        .fetchOne());
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
@@ -148,7 +148,7 @@ public class MemberService {
             throw new BadRequestException(AuthErrorType.TOKEN_NOT_EQUALS);
         }
 
-        String newAccessToken = jwtUtils.generateAccessToken(memberEntity);
+        String newAccessToken = jwtUtils.generateAccessToken(memberEntity.getNickname(), memberId);
         newAccessToken = jwtUtils.includeBearer(newAccessToken);
 
         return AuthResponseMapper.from(newAccessToken);

--- a/src/test/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvControllerTest.java
+++ b/src/test/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvControllerTest.java
@@ -47,7 +47,9 @@ class CctvControllerTest extends ControllerTestConfig {
                         .password("testpassword")
                         .build();
         memberRepository.save(member);
-        accessToken = jwtUtils.includeBearer(jwtUtils.generateAccessToken(member));
+        accessToken =
+                jwtUtils.includeBearer(
+                        jwtUtils.generateAccessToken(member.getNickname(), member.getId()));
     }
 
     @Test


### PR DESCRIPTION
### 📋 상세 설명
- 로그인에 성공했을 때, 그룹에 가입했는지 / 역할이 무엇인지에 따라 화면 분기 처리가 필요합니다.
- 로그인 성공 응답에 해당 정보를 함께 보내 줍니다.
- 쿼리문을 잘 살펴보면, member 기준으로 조회하며 여기에 groupmember를 join하는 형태입니다.
- 따라서 member가 없는 경우 null error를 발생시키는 것은 유지하면서 groupmember 정보가 있다면 응답을 보내주고, 그렇지 않다면 null을 반환하게 됩니다.
- 응답이 null인 경우 프론트에서는 받지 않는 게 편하므로 JsonInclude로 null이 아닌 필드만 응답하고 있습니다.

### 📸 스크린샷
<img width="840" alt="Screenshot 2024-11-23 at 20 45 36" src="https://github.com/user-attachments/assets/bba486cd-9efd-4954-af02-f72b5ba1d94e">
<img width="838" alt="Screenshot 2024-11-23 at 20 45 49" src="https://github.com/user-attachments/assets/0aba16c2-ba6e-419a-9d15-c4e54b4399be">
<img width="841" alt="Screenshot 2024-11-23 at 20 46 03" src="https://github.com/user-attachments/assets/a29b0bae-d1b5-4e5a-93fb-24e03f0fdbc3">
<img width="839" alt="Screenshot 2024-11-23 at 20 54 02" src="https://github.com/user-attachments/assets/4eaa7d81-04e4-41cf-8689-f121dd0a5fc3">

### 📚 자료
- 쿼리는 단 한 번 실행됩니다. (JwtFilter 안 거치는 API)
  ```
  Hibernate: 
    select
        me1_0.id,
        me1_0.nickname,
        me1_0.password,
        (gme1_0.id is not null),
        gme1_0.role 
    from
        member me1_0 
    left join
        group_member gme1_0 
            on gme1_0.member_id=me1_0.id 
    where
        me1_0.email=?
  ```