### PR TITLE
feat: 회원 상세 정보 조회 시 그룹 정보도 함께 조회

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberApi.java
@@ -8,7 +8,7 @@ import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
 import org.ioteatime.meonghanyangserver.group.dto.response.UpdateNicknameAndGroupNameResponse;
 import org.ioteatime.meonghanyangserver.member.dto.request.ChangePasswordRequest;
 import org.ioteatime.meonghanyangserver.member.dto.request.UpdateNicknameAndGroupNameRequest;
-import org.ioteatime.meonghanyangserver.member.dto.response.MemberDetailResponse;
+import org.ioteatime.meonghanyangserver.member.dto.response.MemberWithGroupDetailResponse;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface MemberApi {
 
     @Operation(summary = "회원 상세 정보를 조회합니다.", description = "담당자: 임지인")
-    Api<MemberDetailResponse> getMemberDetail(@PathVariable("memberId") Long memberId);
+    Api<MemberWithGroupDetailResponse> getMemberDetail(@PathVariable("memberId") Long memberId);
 
     @Operation(summary = "회원 정보를 삭제합니다.", description = "담당자: 임지인")
     Api<Object> deleteMember(@LoginMember Long memberId);
@@ -35,7 +35,4 @@ public interface MemberApi {
                     "담당자: 양원채\n\n닉네임 또는 그룹명을 갱신할 수 있으며, 한꺼번에 갱신도 가능합니다.\n\n갱신하고 싶지 않은 필드는 아예 적지 않거나 null로 담아 요청하시면 됩니다. 응답으로는 변경된 사항만 응답합니다.")
     Api<UpdateNicknameAndGroupNameResponse> updateNicknameAndGroupName(
             @LoginMember Long memberId, @RequestBody UpdateNicknameAndGroupNameRequest request);
-
-    @Operation(summary = "로그아웃을 진행합니다.", description = "담당자: 최민석")
-    Api<?> logout();
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/controller/MemberController.java
@@ -10,7 +10,7 @@ import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
 import org.ioteatime.meonghanyangserver.group.dto.response.UpdateNicknameAndGroupNameResponse;
 import org.ioteatime.meonghanyangserver.member.dto.request.ChangePasswordRequest;
 import org.ioteatime.meonghanyangserver.member.dto.request.UpdateNicknameAndGroupNameRequest;
-import org.ioteatime.meonghanyangserver.member.dto.response.MemberDetailResponse;
+import org.ioteatime.meonghanyangserver.member.dto.response.MemberWithGroupDetailResponse;
 import org.ioteatime.meonghanyangserver.member.service.MemberService;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,8 +21,9 @@ public class MemberController implements MemberApi {
     private final MemberService memberService;
 
     @GetMapping("/{memberId}")
-    public Api<MemberDetailResponse> getMemberDetail(@PathVariable("memberId") Long memberId) {
-        MemberDetailResponse userDto = memberService.getMemberDetail(memberId);
+    public Api<MemberWithGroupDetailResponse> getMemberDetail(
+            @PathVariable("memberId") Long memberId) {
+        MemberWithGroupDetailResponse userDto = memberService.getMemberDetail(memberId);
         return Api.success(AuthSuccessType.GET_USER_DETAIL, userDto);
     }
 

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/dto/response/GroupDetailResponse.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/dto/response/GroupDetailResponse.java
@@ -1,0 +1,14 @@
+package org.ioteatime.meonghanyangserver.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.ioteatime.meonghanyangserver.group.domain.GroupEntity;
+
+@Schema(description = "그룹의 상세 정보 조회")
+public record GroupDetailResponse(
+        @NotNull @Schema(description = "그룹 ID", example = "1") Long id,
+        @NotNull @Schema(description = "그룹 이름", example = "멍하냥 그룹") String groupName) {
+    public static GroupDetailResponse from(GroupEntity group) {
+        return new GroupDetailResponse(group.getId(), group.getGroupName());
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/dto/response/MemberWithGroupDetailResponse.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/dto/response/MemberWithGroupDetailResponse.java
@@ -1,0 +1,16 @@
+package org.ioteatime.meonghanyangserver.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Schema(description = "회원 및 그룹 정보 조회")
+public record MemberWithGroupDetailResponse(
+        @NotNull @Schema(description = "회원 정보") MemberDetailResponse member,
+        @Schema(description = "그룹 정보") GroupDetailResponse group) {
+    @Builder
+    public MemberWithGroupDetailResponse(MemberDetailResponse member, GroupDetailResponse group) {
+        this.member = member;
+        this.group = group;
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/mapper/MemberResponseMapper.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/mapper/MemberResponseMapper.java
@@ -1,11 +1,21 @@
 package org.ioteatime.meonghanyangserver.member.mapper;
 
+import org.ioteatime.meonghanyangserver.group.domain.GroupEntity;
 import org.ioteatime.meonghanyangserver.member.domain.MemberEntity;
+import org.ioteatime.meonghanyangserver.member.dto.response.GroupDetailResponse;
 import org.ioteatime.meonghanyangserver.member.dto.response.MemberDetailResponse;
+import org.ioteatime.meonghanyangserver.member.dto.response.MemberWithGroupDetailResponse;
 
 public class MemberResponseMapper {
-    public static MemberDetailResponse from(MemberEntity member) {
-        return new MemberDetailResponse(
-                member.getId(), member.getEmail(), member.getProfileImgUrl(), member.getNickname());
+    public static MemberWithGroupDetailResponse from(MemberEntity member, GroupEntity group) {
+        MemberDetailResponse memberDetail = MemberDetailResponse.from(member);
+        if (group != null) {
+            GroupDetailResponse groupDetail = GroupDetailResponse.from(group);
+            return MemberWithGroupDetailResponse.builder()
+                    .member(memberDetail)
+                    .group(groupDetail)
+                    .build();
+        }
+        return MemberWithGroupDetailResponse.builder().member(memberDetail).build();
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package org.ioteatime.meonghanyangserver.member.service;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.auth.dto.reponse.RefreshResponse;
 import org.ioteatime.meonghanyangserver.auth.mapper.AuthResponseMapper;
@@ -57,11 +58,11 @@ public class MemberService {
                         .findById(memberId)
                         .orElseThrow(() -> new NotFoundException(AuthErrorType.NOT_FOUND));
 
-        GroupMemberEntity groupMemberEntity =
-                groupMemberRepository.findByMemberId(memberId).orElse(null);
+        Optional<GroupMemberEntity> groupMemberEntity =
+                groupMemberRepository.findByMemberId(memberId);
         GroupEntity groupEntity = null;
-        if (groupMemberEntity != null) {
-            groupEntity = groupMemberEntity.getGroup();
+        if (groupMemberEntity.isPresent()) {
+            groupEntity = groupMemberEntity.get().getGroup();
         }
 
         return MemberResponseMapper.from(memberEntity, groupEntity);

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
@@ -23,7 +23,7 @@ import org.ioteatime.meonghanyangserver.groupmember.repository.GroupMemberReposi
 import org.ioteatime.meonghanyangserver.member.domain.MemberEntity;
 import org.ioteatime.meonghanyangserver.member.dto.request.ChangePasswordRequest;
 import org.ioteatime.meonghanyangserver.member.dto.request.UpdateNicknameAndGroupNameRequest;
-import org.ioteatime.meonghanyangserver.member.dto.response.MemberDetailResponse;
+import org.ioteatime.meonghanyangserver.member.dto.response.MemberWithGroupDetailResponse;
 import org.ioteatime.meonghanyangserver.member.mapper.MemberResponseMapper;
 import org.ioteatime.meonghanyangserver.member.repository.MemberRepository;
 import org.ioteatime.meonghanyangserver.redis.AccessTokenRepository;
@@ -51,13 +51,20 @@ public class MemberService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final AccessTokenRepository accessTokenRepository;
 
-    public MemberDetailResponse getMemberDetail(Long memberId) {
+    public MemberWithGroupDetailResponse getMemberDetail(Long memberId) {
         MemberEntity memberEntity =
                 memberRepository
                         .findById(memberId)
                         .orElseThrow(() -> new NotFoundException(AuthErrorType.NOT_FOUND));
 
-        return MemberResponseMapper.from(memberEntity);
+        GroupMemberEntity groupMemberEntity =
+                groupMemberRepository.findByMemberId(memberId).orElse(null);
+        GroupEntity groupEntity = null;
+        if (groupMemberEntity != null) {
+            groupEntity = groupMemberEntity.getGroup();
+        }
+
+        return MemberResponseMapper.from(memberEntity, groupEntity);
     }
 
     // NOTE.


### PR DESCRIPTION
### 📋 상세 설명
- 회원 상세 정보 조회 시 그룹 정보도 함께 조회할 수 있도록 응답 스펙을 변경하였습니다.

### 📸 스크린샷
<img width="616" alt="Screenshot 2024-11-27 at 10 11 07" src="https://github.com/user-attachments/assets/f1087d19-1e63-4939-b423-4a0ef06ab768">