### PR TITLE
feat: 임시 비밀번호 발급 api 구현

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthApi.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.ioteatime.meonghanyangserver.auth.dto.reponse.LoginResponse;
 import org.ioteatime.meonghanyangserver.auth.dto.request.EmailRequest;
+import org.ioteatime.meonghanyangserver.auth.dto.request.IssuePasswordRequest;
 import org.ioteatime.meonghanyangserver.auth.dto.request.LoginRequest;
 import org.ioteatime.meonghanyangserver.auth.dto.request.VerifyEmailRequest;
 import org.ioteatime.meonghanyangserver.common.api.Api;
@@ -27,4 +28,7 @@ public interface AuthApi {
 
     @Operation(summary = "이메일 중복을 확인 합니다.", description = "담당자: 조경재")
     Api<?> duplicateEmail(@Valid @RequestBody EmailRequest email);
+
+    @Operation(summary = "임시 비밀번호를 발급해줍니다.", description = "담당자: 최민석")
+    Api<?> issuePassword(@Valid @RequestBody IssuePasswordRequest issuePasswordRequest);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthController.java
@@ -47,7 +47,7 @@ public class AuthController implements AuthApi {
     @PatchMapping("/change-password")
     public Api<?> issuePassword(@Valid @RequestBody IssuePasswordRequest issuePasswordRequest) {
         authService.issuePassword(issuePasswordRequest);
-        return null;
+        return Api.success(AuthSuccessType.ISSUE_PASSWORD);
     }
 
     @PostMapping("/sign-in")

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/controller/AuthController.java
@@ -1,8 +1,10 @@
 package org.ioteatime.meonghanyangserver.auth.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.auth.dto.reponse.LoginResponse;
 import org.ioteatime.meonghanyangserver.auth.dto.request.EmailRequest;
+import org.ioteatime.meonghanyangserver.auth.dto.request.IssuePasswordRequest;
 import org.ioteatime.meonghanyangserver.auth.dto.request.LoginRequest;
 import org.ioteatime.meonghanyangserver.auth.dto.request.VerifyEmailRequest;
 import org.ioteatime.meonghanyangserver.auth.service.AuthService;
@@ -40,6 +42,12 @@ public class AuthController implements AuthApi {
     public Api<?> duplicateEmail(@RequestBody EmailRequest emailReq) {
         authService.verifyEmail(emailReq.email());
         return Api.success(AuthSuccessType.EMAIL_VERIFIED);
+    }
+
+    @PatchMapping("/change-password")
+    public Api<?> issuePassword(@Valid @RequestBody IssuePasswordRequest issuePasswordRequest) {
+        authService.issuePassword(issuePasswordRequest);
+        return null;
     }
 
     @PostMapping("/sign-in")

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/dto/request/IssuePasswordRequest.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/dto/request/IssuePasswordRequest.java
@@ -3,6 +3,6 @@ package org.ioteatime.meonghanyangserver.auth.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
-
+@Schema(description = "임시 비밀번호 발급을 위한 요청")
 public record IssuePasswordRequest(
         @Email @NotNull @Schema(description = "이메일", example = "example@gmail.com") String email) {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/dto/request/IssuePasswordRequest.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/dto/request/IssuePasswordRequest.java
@@ -1,0 +1,8 @@
+package org.ioteatime.meonghanyangserver.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+
+public record IssuePasswordRequest(
+        @Email @NotNull @Schema(description = "이메일", example = "example@gmail.com") String email) {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/dto/request/IssuePasswordRequest.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/dto/request/IssuePasswordRequest.java
@@ -3,6 +3,7 @@ package org.ioteatime.meonghanyangserver.auth.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
+
 @Schema(description = "임시 비밀번호 발급을 위한 요청")
 public record IssuePasswordRequest(
         @Email @NotNull @Schema(description = "이메일", example = "example@gmail.com") String email) {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/auth/service/AuthService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/auth/service/AuthService.java
@@ -129,12 +129,13 @@ public class AuthService {
 
     @Transactional
     public void issuePassword(IssuePasswordRequest issuePasswordRequest) {
-        // 임시비밀번호 발급
-        String password = getCode();
+
         MemberEntity memberEntity =
                 memberRepository
                         .findByEmail(issuePasswordRequest.email())
                         .orElseThrow(() -> new NotFoundException(AuthErrorType.NOT_FOUND));
+        // 임시비밀번호 발급
+        String password = getCode();
 
         String encodedPassword = bCryptPasswordEncoder.encode(password);
 

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthSuccessType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthSuccessType.java
@@ -13,7 +13,7 @@ public enum AuthSuccessType implements SuccessTypeCode {
     UPDATE_NICKNAME(200, "OK", "닉네임 수정에 성공하였습니다."),
     UPDATE_NICKNAME_AND_GROUP_NAME(200, "OK", "닉네임과 그룹 이름 변경에 성공하였습니다."),
     SIGN_OUT(200, "OK", "로그아웃에 성공하였습니다."),
-    ISSUE_PASSWORD(200,"OK","임시 비밀번호 발급에 성공하였습니다.");
+    ISSUE_PASSWORD(200, "OK", "임시 비밀번호 발급에 성공하였습니다.");
 
     private final Integer code;
     private final String message;

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthSuccessType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthSuccessType.java
@@ -12,7 +12,8 @@ public enum AuthSuccessType implements SuccessTypeCode {
     VERIFY_EMAIL_CODE(200, "OK", "이메일 인증 코드 검증에 성공하였습니다."),
     UPDATE_NICKNAME(200, "OK", "닉네임 수정에 성공하였습니다."),
     UPDATE_NICKNAME_AND_GROUP_NAME(200, "OK", "닉네임과 그룹 이름 변경에 성공하였습니다."),
-    SIGN_OUT(200, "OK", "로그아웃에 성공하였습니다.");
+    SIGN_OUT(200, "OK", "로그아웃에 성공하였습니다."),
+    ISSUE_PASSWORD(200,"OK","임시 비밀번호 발급에 성공하였습니다.");
 
     private final Integer code;
     private final String message;

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/domain/MemberEntity.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/domain/MemberEntity.java
@@ -72,4 +72,9 @@ public class MemberEntity {
         this.nickname = nickname;
         return this;
     }
+
+    public MemberEntity updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+        return this;
+    }
 }


### PR DESCRIPTION
### 📋 상세 설명
- 비밀번호 잃어버렸을 때 임시 비밀번호 재발급 api입니다.

### 📸 스크린샷
- 이메일 인증 발급 성공
![스크린샷 2024-11-29 오후 3 54 00](https://github.com/user-attachments/assets/d75ed506-39f1-4f8c-8bc2-65fbfe4b13d1)

![스크린샷 2024-11-29 오후 3 52 02](https://github.com/user-attachments/assets/4444932c-2a5e-4329-86cc-282d52c3283d)

![스크린샷 2024-11-29 오후 3 53 47](https://github.com/user-attachments/assets/4a1fa401-cde5-4d40-8fee-7850152c64b0)

- 이메일 없을 때
![스크린샷 2024-11-29 오후 3 54 52](https://github.com/user-attachments/assets/1a5f5ee2-b362-435c-a87e-c04d127ccfc5)
