### PR TITLE
fix: 그룹 회원 추가 시 기존 그룹 회원 정보가 덮어 씌워지는 문제 해결 및 의존성 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,4 +96,5 @@ jobs:
           envs: IMAGE_FULL_URL, DOCKERHUB_IMAGE_NAME
           script: |
             echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u "${{ env.DOCKERHUB_USERNAME }}" --password-stdin
+            docker compose down --remove-orphans
             docker compose up --build -d

--- a/src/main/java/org/ioteatime/meonghanyangserver/groupmember/controller/GroupMemberApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/groupmember/controller/GroupMemberApi.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
 import org.ioteatime.meonghanyangserver.groupmember.dto.request.JoinGroupMemberRequest;
+import org.ioteatime.meonghanyangserver.groupmember.dto.response.GroupMemberInfoListResponse;
+import org.ioteatime.meonghanyangserver.groupmember.dto.response.GroupMemberResponse;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -12,21 +14,22 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface GroupMemberApi {
 
     @Operation(summary = "참여자가 그룹과 역할을 조회합니다.", description = "담당자: 임지인")
-    public Api<?> getGroupMemberInfo(@LoginMember Long memberId);
+    Api<GroupMemberResponse> getGroupMemberInfo(@LoginMember Long memberId);
 
     @Operation(summary = "참여자가 그룹에 입장을 요청합니다.", description = "담당자: 임지인")
-    public Api<Void> joinGroupAsMember(
+    Api<?> joinGroupAsMember(
             @LoginMember Long memberId, @RequestBody JoinGroupMemberRequest joinGroupMemberRequest);
 
     @Operation(summary = "방장이 그룹에서 참여자를 제외합니다.", description = "담당자: 최민석")
-    public Api<?> deleteMasterGroupMember(
+    Api<?> deleteMasterGroupMember(
             @LoginMember Long memberId,
             @PathVariable Long groupId,
             @PathVariable Long groupMemberId);
 
     @Operation(summary = "그룹에서 참여자가 스스로 퇴장합니다.", description = "담당자: 최민석")
-    public Api<?> deleteGroupMember(@LoginMember Long memberId, @PathVariable Long groupId);
+    Api<?> deleteGroupMember(@LoginMember Long memberId, @PathVariable Long groupId);
 
     @Operation(summary = "그룹 참여자들의 정보를 조회합니다.", description = "담당자: 최민석")
-    public Api<?> getGroupMemberInfoList(@LoginMember Long memberId, @PathVariable Long groupId);
+    Api<GroupMemberInfoListResponse> getGroupMemberInfoList(
+            @LoginMember Long memberId, @PathVariable Long groupId);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/groupmember/controller/GroupMemberController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/groupmember/controller/GroupMemberController.java
@@ -17,13 +17,13 @@ public class GroupMemberController implements GroupMemberApi {
     private final GroupMemberService groupMemberService;
 
     @GetMapping
-    public Api<?> getGroupMemberInfo(@LoginMember Long memberId) {
+    public Api<GroupMemberResponse> getGroupMemberInfo(@LoginMember Long memberId) {
         GroupMemberResponse groupMemberResponse = groupMemberService.getGroupMemberInfo(memberId);
         return Api.success(GroupSuccessType.GET_GROUP_MEMBER_INFO, groupMemberResponse);
     }
 
     @PostMapping("/viewer")
-    public Api<Void> joinGroupAsMember(
+    public Api<?> joinGroupAsMember(
             @LoginMember Long memberId,
             @RequestBody JoinGroupMemberRequest joinGroupMemberRequest) {
         groupMemberService.joinGroupMember(memberId, joinGroupMemberRequest);
@@ -33,20 +33,22 @@ public class GroupMemberController implements GroupMemberApi {
     @DeleteMapping("/{groupId}/member/{groupMemberId}")
     public Api<?> deleteMasterGroupMember(
             @LoginMember Long memberId,
-            @PathVariable Long groupId,
-            @PathVariable Long groupMemberId) {
+            @PathVariable("groupId") Long groupId,
+            @PathVariable("groupMemberId") Long groupMemberId) {
         groupMemberService.deleteMasterGroupMember(memberId, groupId, groupMemberId);
         return Api.success(GroupSuccessType.DELETE_GROUP_MEMBER);
     }
 
     @DeleteMapping("/{groupId}/member")
-    public Api<?> deleteGroupMember(@LoginMember Long memberId, @PathVariable Long groupId) {
+    public Api<?> deleteGroupMember(
+            @LoginMember Long memberId, @PathVariable("groupId") Long groupId) {
         groupMemberService.deleteGroupMember(memberId, groupId);
         return Api.success(GroupSuccessType.DELETE_GROUP_MEMBER);
     }
 
     @GetMapping("/{groupId}/member")
-    public Api<?> getGroupMemberInfoList(@LoginMember Long memberId, @PathVariable Long groupId) {
+    public Api<GroupMemberInfoListResponse> getGroupMemberInfoList(
+            @LoginMember Long memberId, @PathVariable("groupId") Long groupId) {
         GroupMemberInfoListResponse groupMemberInfoListResponse =
                 groupMemberService.getGroupMemberInfoList(memberId, groupId);
         return Api.success(

--- a/src/main/java/org/ioteatime/meonghanyangserver/groupmember/doamin/GroupMemberEntity.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/groupmember/doamin/GroupMemberEntity.java
@@ -43,11 +43,20 @@ public class GroupMemberEntity {
         this.group = group;
     }
 
-    @Builder
     public GroupMemberEntity(Long id, GroupMemberRole role, String thingId, MemberEntity member) {
         this.id = id;
         this.role = role;
         this.member = member;
         this.thingId = thingId;
+    }
+
+    public static GroupMemberEntity from(
+            GroupMemberRole role, String thingId, GroupEntity group, MemberEntity member) {
+        return GroupMemberEntity.builder()
+                .role(role)
+                .thingId(thingId)
+                .group(group)
+                .member(member)
+                .build();
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/groupmember/repository/GroupMemberRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/groupmember/repository/GroupMemberRepository.java
@@ -13,7 +13,7 @@ public interface GroupMemberRepository {
 
     Optional<GroupMemberEntity> findByMemberId(Long memberId);
 
-    GroupEntity findGroupMember(Long memberId);
+    Optional<GroupEntity> findGropFromGroupMember(Long memberId);
 
     void deleteById(Long id);
 

--- a/src/main/java/org/ioteatime/meonghanyangserver/groupmember/repository/GroupMemberRepositoryImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/groupmember/repository/GroupMemberRepositoryImpl.java
@@ -37,12 +37,13 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepository {
     }
 
     @Override
-    public GroupEntity findGroupMember(Long memberId) {
-        return jpaQueryFactory
-                .select(groupMemberEntity.group)
-                .from(groupMemberEntity)
-                .where(groupMemberEntity.member.id.eq(memberId))
-                .fetchOne();
+    public Optional<GroupEntity> findGropFromGroupMember(Long memberId) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .select(groupMemberEntity.group)
+                        .from(groupMemberEntity)
+                        .where(groupMemberEntity.member.id.eq(memberId))
+                        .fetchOne());
     }
 
     @Override

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -10,4 +10,4 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100
     hibernate:
-      ddl-auto: create
+      ddl-auto: update


### PR DESCRIPTION
### 📋 상세 설명
- 그룹 회원 추가 시 기존 그룹 회원 정보가 덮어 씌워지는 문제를 해결하였습니다.
- id가 동일하게 입력되어 create가 아닌 update가 진행되었습니다.
- service 레이어가 service 레이어를 의존하고 있던 의존성을 수정하였습니다.

### 📸 스크린샷
<img width="581" alt="Screenshot 2024-11-29 at 16 11 09" src="https://github.com/user-attachments/assets/fa6d79fc-91b4-4e62-9695-d56db4ac85a2">