### PR TITLE
fix: 토픽 재구독 예외 처리 추가

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/fcm/service/FcmService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/fcm/service/FcmService.java
@@ -13,6 +13,8 @@ import org.ioteatime.meonghanyangserver.groupmember.repository.GroupMemberReposi
 import org.ioteatime.meonghanyangserver.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class FcmService {
@@ -26,11 +28,8 @@ public class FcmService {
                 .updateFcmTokenById(memberId, token)
                 .orElseThrow(() -> new NotFoundException(AuthErrorType.NOT_FOUND));
         // 토픽이 갱신될 때마다 토픽 다시 구독
-        GroupEntity group =
-                groupMemberRepository
-                        .findGroupFromGroupMember(memberId)
-                        .orElseThrow(() -> new NotFoundException(GroupErrorType.NOT_FOUND));
-        fcmClient.subTopic(token, group.getFcmTopic());
+        groupMemberRepository.findGroupFromGroupMember(memberId)
+                .ifPresent(groupEntity -> fcmClient.subTopic(token, groupEntity.getFcmTopic()));
     }
 
     public FcmTopicResponse findFcmTopicByGroupId(Long memberId) {


### PR DESCRIPTION
### 📋 상세 설명
- 토픽 재구독 예외 처리를 추가했습니다.
- 그룹이 없으면 예외가 발생하는 게 아니라 FCM 토픽만 구독하지 않게 변경했습니다.