### PR TITLE
feat: CCTV AT 구현

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvApi.java
@@ -21,4 +21,7 @@ public interface CctvApi {
     @Operation(summary = "CCTV 이름 변경", description = "담당자: 양원채")
     Api<CctvInfoResponse> updateNickName(
             @LoginMember Long memberId, @RequestBody UpdateCctvNickname request);
+
+    @Operation(summary = "CCTV 정보", description = "담당자: 양원채")
+    Api<CctvInfoResponse> cctvInfo(@PathVariable("cctvId") Long cctvId);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvController.java
@@ -35,4 +35,10 @@ public class CctvController implements CctvApi {
         CctvInfoResponse response = cctvService.updateNickname(memberId, request);
         return Api.success(CctvSuccessType.UPDATE_NICKNAME, response);
     }
+
+    @GetMapping("/{cctvId}")
+    public Api<CctvInfoResponse> cctvInfo(@PathVariable("cctvId") Long cctvId) {
+        CctvInfoResponse cctvInfoResponse = cctvService.cctvInfo(cctvId);
+        return Api.success(CctvSuccessType.GET_CCTV_DETAIL, cctvInfoResponse);
+    }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvDeviceApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvDeviceApi.java
@@ -9,11 +9,12 @@ import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "CCTV Device Api", description = "CCTV 기기 관련 API 목록입니다.")
+@Tag(name = "CCTV Device Api", description = "CCTV 기기에서 요청할 수 있는 API 목록입니다.")
 public interface CctvDeviceApi {
+    // 토큰이 없어도 가능해야 함
     @Operation(summary = "CCTV 기기 생성 요청", description = "담당자: 임지인")
     Api<CreateCctvResponse> createCctv(@RequestBody CreateCctvRequest createCctvRequest);
 
     @Operation(summary = "CCTV 정보", description = "담당자: 최민석")
-    Api<CctvInfoResponse> cctvInfo(@PathVariable Long cctvId);
+    Api<CctvInfoResponse> cctvInfo(@PathVariable("cctvId") Long cctvId);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvDeviceController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/controller/CctvDeviceController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/open-api/cctv")
+@RequestMapping("/api/cctv-device")
 public class CctvDeviceController implements CctvDeviceApi {
     private final CctvService cctvService;
 
@@ -22,7 +22,7 @@ public class CctvDeviceController implements CctvDeviceApi {
     }
 
     @GetMapping("/{cctvId}")
-    public Api<CctvInfoResponse> cctvInfo(@PathVariable Long cctvId) {
+    public Api<CctvInfoResponse> cctvInfo(@PathVariable("cctvId") Long cctvId) {
         CctvInfoResponse cctvInfoResponse = cctvService.cctvInfo(cctvId);
         return Api.success(CctvSuccessType.GET_CCTV_DETAIL, cctvInfoResponse);
     }

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/dto/response/CreateCctvResponse.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/dto/response/CreateCctvResponse.java
@@ -5,4 +5,9 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "CCTV 생성 응답")
 public record CreateCctvResponse(
-        @NotNull @Schema(description = "CCTV ID", example = "1") Long cctvId) {}
+        @NotNull @Schema(description = "CCTV ID", example = "1") Long cctvId,
+        @NotNull
+                @Schema(
+                        description = "CCTV AccessToken",
+                        example = "Bearer eyJ23Gc2fNCJ9.eywguYW161...")
+                String accessToken) {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/cctv/mapper/CctvResponseMapper.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/cctv/mapper/CctvResponseMapper.java
@@ -19,7 +19,7 @@ public class CctvResponseMapper {
         return new CctvInfoListResponse(cctvInfoResponseList);
     }
 
-    public static CreateCctvResponse from(Long cctvId) {
-        return new CreateCctvResponse(cctvId);
+    public static CreateCctvResponse from(Long cctvId, String accessToken) {
+        return new CreateCctvResponse(cctvId, accessToken);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/clients/s3/S3Client.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/clients/s3/S3Client.java
@@ -21,10 +21,11 @@ public class S3Client {
     @Value("${aws.s3-bucket}")
     private String bucket;
 
-    public String generatePreSignUrl(String filename, HttpMethod httpMethod) {
+    public String generatePreSignUrl(
+            String filename, HttpMethod httpMethod, Integer standard, Integer amount) {
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(new Date());
-        calendar.add(Calendar.MINUTE, 10);
+        calendar.add(standard, amount);
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
                 new GeneratePresignedUrlRequest(bucket, filename)
                         .withMethod(httpMethod)

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/constant/JwtTokenType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/constant/JwtTokenType.java
@@ -1,0 +1,15 @@
+package org.ioteatime.meonghanyangserver.common.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum JwtTokenType {
+    MEMBER_JWT("memberJwt"),
+    CCTV_JWT("cctvJwt");
+
+    private String value;
+
+    JwtTokenType(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthErrorType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/AuthErrorType.java
@@ -10,7 +10,8 @@ public enum AuthErrorType implements ErrorTypeCode {
     PASSWORD_INVALID("BAD REQUEST", "비밀번호가 유효하지 않습니다."),
     CODE_NOT_EQUALS("BAD REQUEST", "이메일 인증 코드가 일치하지 않습니다."),
     EMAIL_DUPLICATED("BAD REQUEST", "이메일이 중복되었습니다."),
-    REFRESH_TOKEN_NOT_FOUND("NOT FOUND", "REFRESH TOKEN을 찾을 수 없습니다.");
+    REFRESH_TOKEN_NOT_FOUND("NOT FOUND", "REFRESH TOKEN을 찾을 수 없습니다."),
+    INVALID_AUTH_JWT_REQUEST("BAD REQUEST", "회원이 요청할 수 없는 잘못된 경로입니다.");
 
     private final String message;
     private final String description;

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/CctvErrorType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/CctvErrorType.java
@@ -3,7 +3,9 @@ package org.ioteatime.meonghanyangserver.common.type;
 public enum CctvErrorType implements ErrorTypeCode {
     ALREADY_EXIST("CCTV ALREADY EXIST", "이미 존재하는 CCTV 기기입니다."),
     ONLY_MASTER_CAN_DELETE("BAD REQUEST", "CCTV는 MASTER만 삭제할 수 있습니다."),
-    NOT_FOUND("NOT FOUND", "CCTV를 찾을 수 없습니다.");
+    NOT_FOUND("NOT FOUND", "CCTV를 찾을 수 없습니다."),
+    INVALID_CCTV_JWT_REQUEST("BAD REQUEST", "CCTV가 요청할 수 없는 잘못된 경로입니다."),
+    INVALID_TOKEN("INTERNAL SERVER", "CCTV TOKEN이 만료되었습니다.");
 
     private final String message;
     private final String description;

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/VideoSuccessType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/VideoSuccessType.java
@@ -1,8 +1,8 @@
 package org.ioteatime.meonghanyangserver.common.type;
 
 public enum VideoSuccessType implements SuccessTypeCode {
-    GET_PRESIGNED_URL(200, "OK", "Presigned Url 조회에 성공하였습니다."),
-    GET_VIDEO_INFO(200, "OK", "동영상 정보 조회에 성공하였습니다.");
+    GET_VIDEO_INFO(200, "OK", "동영상 정보 조회에 성공하였습니다."),
+    GENERATE_PRESIGNED_URL(200, "OK", "동영상 Presigned URL 생성에 성공하였습니다.");
 
     private final Integer code;
     private final String message;

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/utils/JwtCctvUtils.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/utils/JwtCctvUtils.java
@@ -1,0 +1,69 @@
+package org.ioteatime.meonghanyangserver.common.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Objects;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.ioteatime.meonghanyangserver.cctv.domain.CctvEntity;
+import org.ioteatime.meonghanyangserver.common.exception.UnauthorizedException;
+import org.ioteatime.meonghanyangserver.common.type.CctvErrorType;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtCctvUtils {
+    private final SecretKey cctvKey;
+
+    public JwtCctvUtils(Environment env) {
+        String cctvSecretKeyString = env.getProperty("token.cctv-secret");
+        byte[] decodedCctvKey = Base64.getDecoder().decode(cctvSecretKeyString);
+        this.cctvKey = Keys.hmacShaKeyFor(decodedCctvKey);
+    }
+
+    public String generateCctvAccessToken(String cctvName, Long cctvId) {
+        Date nowDate = new Date();
+        String jwtToken =
+                Jwts.builder()
+                        .claim("name", cctvName)
+                        .claim("sub", "meong-ha-nyang")
+                        .claim("jti", String.valueOf(cctvId))
+                        .claim("iat", nowDate)
+                        .claim("exp", null)
+                        .signWith(cctvKey)
+                        .compact();
+        log.debug(jwtToken);
+        return jwtToken;
+    }
+
+    private Claims getAllCctvClaimsFromToken(String token) {
+        try {
+            Jws<Claims> jwt =
+                    Jwts.parser()
+                            .verifyWith(cctvKey) // SecretKey를 이용한 서명 검증
+                            .build()
+                            .parseSignedClaims(token);
+            return jwt.getPayload();
+        } catch (ExpiredJwtException exception) {
+            throw new UnauthorizedException(CctvErrorType.INVALID_TOKEN);
+        }
+    }
+
+    public Long getCctvIdFromToken(String token) {
+        final Claims claims = getAllCctvClaimsFromToken(token);
+        return Long.valueOf(String.valueOf(claims.get("jti")));
+    }
+
+    public boolean validateToken(String token, CctvEntity cctvEntity) {
+        Long jwtId = getCctvIdFromToken(token);
+        Long id = cctvEntity.getId();
+
+        return id != null && Objects.equals(jwtId, id);
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/utils/JwtUtils.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/utils/JwtUtils.java
@@ -5,12 +5,14 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Date;
 import java.util.Objects;
 import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
+import org.ioteatime.meonghanyangserver.common.constant.JwtTokenType;
 import org.ioteatime.meonghanyangserver.common.exception.UnauthorizedException;
 import org.ioteatime.meonghanyangserver.common.type.AuthErrorType;
 import org.ioteatime.meonghanyangserver.member.domain.MemberEntity;
@@ -116,5 +118,14 @@ public class JwtUtils {
     // access token 블랙리스트 유무 확인
     public boolean blackListAccessToken(String token) {
         return accessTokenRepository.existsByAccessToken(token);
+    }
+
+    public JwtTokenType findTokenType(String token) {
+        try {
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+            return JwtTokenType.MEMBER_JWT;
+        } catch (SignatureException e) {
+            return JwtTokenType.CCTV_JWT;
+        }
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/config/SecurityConfig.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.ioteatime.meonghanyangserver.handler.CustomLogoutHandler;
 import org.ioteatime.meonghanyangserver.handler.CustomLogoutSuccessHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
@@ -50,6 +51,8 @@ public class SecurityConfig {
         http.authorizeHttpRequests(
                 (auth) ->
                         auth.requestMatchers("/open-api/**", "/swagger-ui/**", "/v3/**", "/error")
+                                .permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/cctv-device")
                                 .permitAll()
                                 .anyRequest()
                                 .authenticated());

--- a/src/main/java/org/ioteatime/meonghanyangserver/filter/JwtRequestFilter.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/filter/JwtRequestFilter.java
@@ -7,14 +7,20 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.ioteatime.meonghanyangserver.cctv.domain.CctvEntity;
+import org.ioteatime.meonghanyangserver.cctv.repository.CctvRepository;
+import org.ioteatime.meonghanyangserver.common.constant.JwtTokenType;
 import org.ioteatime.meonghanyangserver.common.exception.*;
 import org.ioteatime.meonghanyangserver.common.type.AuthErrorType;
+import org.ioteatime.meonghanyangserver.common.type.CctvErrorType;
+import org.ioteatime.meonghanyangserver.common.utils.JwtCctvUtils;
 import org.ioteatime.meonghanyangserver.common.utils.JwtUtils;
-import org.ioteatime.meonghanyangserver.groupmember.repository.GroupMemberRepository;
 import org.ioteatime.meonghanyangserver.member.domain.MemberEntity;
+import org.ioteatime.meonghanyangserver.member.dto.CustomCctvDetail;
 import org.ioteatime.meonghanyangserver.member.dto.CustomUserDetail;
 import org.ioteatime.meonghanyangserver.member.repository.MemberRepository;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -26,8 +32,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtRequestFilter extends OncePerRequestFilter {
     private final JwtUtils jwtUtils;
+    private final JwtCctvUtils jwtCctvUtils;
+    private final CctvRepository cctvRepository;
     private final MemberRepository memberRepository;
-    private final GroupMemberRepository deviceRepository;
 
     @Override
     protected void doFilterInternal(
@@ -38,7 +45,9 @@ public class JwtRequestFilter extends OncePerRequestFilter {
         if (uri.contains("/open-api")
                 || uri.contains("/swagger-ui")
                 || uri.contains("/v3/api-docs")
-                || uri.contains("/static")) {
+                || uri.contains("/static")
+                || (uri.contains("/api/cctv-device")
+                        && request.getMethod().equalsIgnoreCase(HttpMethod.POST.name()))) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -48,39 +57,96 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
         String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            jwtToken = authorizationHeader.substring(7);
-            // access token 블랙리스트 확인
-            if (jwtUtils.blackListAccessToken(jwtToken)) {
-                throw new UnauthorizedException(AuthErrorType.HEADER_INVALID);
-            }
-            jwtId = jwtUtils.getIdFromToken(jwtToken);
-            log.debug("jwt : ", jwtToken);
-        } else {
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
             log.error("Authorization 헤더 누락 또는 토큰 형식 오류");
             throw new UnauthorizedException(AuthErrorType.HEADER_INVALID);
         }
-        if (jwtId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+
+        jwtToken = authorizationHeader.substring(7);
+        // access token 블랙리스트 확인
+        if (jwtUtils.blackListAccessToken(jwtToken)) {
+            throw new UnauthorizedException(AuthErrorType.HEADER_INVALID);
+        }
+
+        if (jwtUtils.findTokenType(jwtToken) == JwtTokenType.CCTV_JWT) {
+            // CCTV JWT인 경우 경로 확인
+            validateCctvRequestPath(JwtTokenType.CCTV_JWT, uri);
+
+            jwtId = jwtCctvUtils.getCctvIdFromToken(jwtToken);
+            log.debug("jwt : ", jwtToken);
+
+            if (jwtId == null || SecurityContextHolder.getContext().getAuthentication() != null) {
+                return;
+            }
+
+            CctvEntity entity =
+                    cctvRepository
+                            .findById(jwtId)
+                            .orElseThrow(() -> new NotFoundException(CctvErrorType.NOT_FOUND));
+
+            log.debug(entity.getCctvNickname());
+            if (!jwtCctvUtils.validateToken(jwtToken, entity)) {
+                SecurityContextHolder.getContext().setAuthentication(null);
+                return;
+            }
+
+            CustomCctvDetail customCctvDetail = new CustomCctvDetail(entity);
+            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                    new UsernamePasswordAuthenticationToken(
+                            customCctvDetail, null, customCctvDetail.getAuthorities());
+            usernamePasswordAuthenticationToken.setDetails(
+                    new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext()
+                    .setAuthentication(usernamePasswordAuthenticationToken);
+        } else if (jwtUtils.findTokenType(jwtToken) == JwtTokenType.MEMBER_JWT) {
+            validateCctvRequestPath(JwtTokenType.MEMBER_JWT, uri);
+
+            jwtId = jwtUtils.getIdFromToken(jwtToken);
+            log.debug("jwt : ", jwtToken);
+
+            if (jwtId == null || SecurityContextHolder.getContext().getAuthentication() != null) {
+                return;
+            }
+
             MemberEntity entity =
                     memberRepository
                             .findById(jwtId)
                             .orElseThrow(() -> new NotFoundException(AuthErrorType.NOT_FOUND));
 
             log.debug(entity.getEmail());
-            if (jwtUtils.validateToken(jwtToken, entity)) {
-                CustomUserDetail customUserDetail = new CustomUserDetail(entity);
-                UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-                        new UsernamePasswordAuthenticationToken(
-                                customUserDetail, null, customUserDetail.getAuthorities());
-                usernamePasswordAuthenticationToken.setDetails(
-                        new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext()
-                        .setAuthentication(usernamePasswordAuthenticationToken);
-            } else {
+            if (!jwtUtils.validateToken(jwtToken, entity)) {
                 SecurityContextHolder.getContext().setAuthentication(null);
                 return;
             }
-            filterChain.doFilter(request, response);
+
+            CustomUserDetail customUserDetail = new CustomUserDetail(entity);
+            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                    new UsernamePasswordAuthenticationToken(
+                            customUserDetail, null, customUserDetail.getAuthorities());
+            usernamePasswordAuthenticationToken.setDetails(
+                    new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext()
+                    .setAuthentication(usernamePasswordAuthenticationToken);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void validateCctvRequestPath(JwtTokenType jwtTokenType, String uri) {
+        // CCTV 요청 경로가 올바르지 않으면 에러
+        boolean isValidPath =
+                uri.contains("/api/video-device")
+                        || uri.contains("/api/cctv-device")
+                        || uri.contains("/api/image-device");
+        if (jwtTokenType == JwtTokenType.CCTV_JWT) {
+            if (isValidPath) {
+                return;
+            }
+            throw new BadRequestException(CctvErrorType.INVALID_CCTV_JWT_REQUEST);
+        } else if (jwtTokenType == JwtTokenType.MEMBER_JWT) {
+            if (isValidPath) {
+                throw new BadRequestException(AuthErrorType.INVALID_AUTH_JWT_REQUEST);
+            }
         }
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/controller/ImageDeviceApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/controller/ImageDeviceApi.java
@@ -4,8 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
+import org.ioteatime.meonghanyangserver.image.dto.request.ImageNameRequest;
 import org.ioteatime.meonghanyangserver.image.dto.response.ImageSaveUrlResponse;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Image Api", description = "Image 관련 API 목록입니다.")
 public interface ImageDeviceApi {
@@ -14,5 +15,5 @@ public interface ImageDeviceApi {
             description =
                     "담당자: 임지인\n\n캡쳐 이미지 저장을 위한 URL 발급 요청입니다.\n\nCCTV의 Access Token과 함께 요청 하시면 됩니다.")
     Api<ImageSaveUrlResponse> getImageSaveUrl(
-            @LoginMember Long cctvId, @PathVariable String fileName);
+            @LoginMember Long cctvId, @RequestBody ImageNameRequest imageNameRequest);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/controller/ImageDeviceApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/controller/ImageDeviceApi.java
@@ -13,6 +13,6 @@ public interface ImageDeviceApi {
             summary = "이미지 저장을 위한 presigned url을 발급 받습니다.",
             description =
                     "담당자: 임지인\n\n캡쳐 이미지 저장을 위한 URL 발급 요청입니다.\n\nCCTV의 Access Token과 함께 요청 하시면 됩니다.")
-    public Api<ImageSaveUrlResponse> getImageSaveUrl(
+    Api<ImageSaveUrlResponse> getImageSaveUrl(
             @LoginMember Long cctvId, @PathVariable String fileName);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/controller/ImageDeviceController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/controller/ImageDeviceController.java
@@ -4,12 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.type.ImageSuccessType;
 import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
+import org.ioteatime.meonghanyangserver.image.dto.request.ImageNameRequest;
 import org.ioteatime.meonghanyangserver.image.dto.response.ImageSaveUrlResponse;
 import org.ioteatime.meonghanyangserver.image.service.ImageService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,10 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class ImageDeviceController implements ImageDeviceApi {
     private final ImageService imageService;
 
-    @GetMapping("/{fileName}")
+    @PostMapping("/presigned-url")
     public Api<ImageSaveUrlResponse> getImageSaveUrl(
-            @LoginMember Long cctvId, @PathVariable String fileName) {
-        ImageSaveUrlResponse imageSaveUrlResponse = imageService.getImageSaveUrl(cctvId, fileName);
+            @LoginMember Long cctvId, @RequestBody ImageNameRequest imageNameRequest) {
+        ImageSaveUrlResponse imageSaveUrlResponse =
+                imageService.getImageSaveUrl(cctvId, imageNameRequest.imageName());
         return Api.success(ImageSuccessType.CREATE_PRESIGNED_URL, imageSaveUrlResponse);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/dto/request/ImageNameRequest.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/dto/request/ImageNameRequest.java
@@ -1,0 +1,8 @@
+package org.ioteatime.meonghanyangserver.image.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "이미지 이름 요청")
+public record ImageNameRequest(
+        @NotNull @Schema(description = "이미지 이름", example = "test-image.jpg") String imageName) {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/service/ImageService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/service/ImageService.java
@@ -2,6 +2,7 @@ package org.ioteatime.meonghanyangserver.image.service;
 
 import com.amazonaws.HttpMethod;
 import java.time.LocalDateTime;
+import java.util.Calendar;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.cctv.repository.CctvRepository;
@@ -43,7 +44,8 @@ public class ImageService {
                         + System.currentTimeMillis()
                         + fileName.substring(fileName.lastIndexOf("."));
 
-        String presignedUrl = s3Client.generatePreSignUrl(fileName, HttpMethod.PUT);
+        String presignedUrl =
+                s3Client.generatePreSignUrl(fileName, HttpMethod.PUT, Calendar.MINUTE, 10);
         return ImageResponseMapper.form(presignedUrl);
     }
 
@@ -66,7 +68,10 @@ public class ImageService {
                                     // 경로를 PresignedUrl로 변경
                                     String preSignedUrl =
                                             s3Client.generatePreSignUrl(
-                                                    image.getImagePath(), HttpMethod.GET);
+                                                    image.getImagePath(),
+                                                    HttpMethod.GET,
+                                                    Calendar.DAY_OF_MONTH,
+                                                    1);
                                     return image.updateToPresignedUrl(preSignedUrl);
                                 })
                         .toList();

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/dto/CustomCctvDetail.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/dto/CustomCctvDetail.java
@@ -1,0 +1,39 @@
+package org.ioteatime.meonghanyangserver.member.dto;
+
+import java.util.Collection;
+import java.util.Collections;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.ioteatime.meonghanyangserver.cctv.domain.CctvEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Data
+@RequiredArgsConstructor
+public class CustomCctvDetail implements UserDetails {
+    private CctvEntity cctvEntity;
+
+    public CustomCctvDetail(CctvEntity cctvEntity) {
+        this.cctvEntity = cctvEntity;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_CCTV"));
+    }
+
+    @Override
+    public String getPassword() {
+        return cctvEntity.getCctvNickname();
+    }
+
+    @Override
+    public String getUsername() {
+        return cctvEntity.getCctvNickname();
+    }
+
+    public Long getId() {
+        return cctvEntity.getId();
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoApi.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "Video Api", description = "Video 관련 API 목록입니다.")
 public interface VideoApi {
     @Operation(summary = "날짜를 사용한 동영상 정보 조회 발급받습니다.", description = "담당자: 최민석")
-    public Api<?> searchToDate(
+    Api<?> searchToDate(
             @LoginMember Long memberId,
             @PathVariable Long groupId,
             @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date);

--- a/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoApi.java
@@ -5,17 +5,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
-import org.ioteatime.meonghanyangserver.video.dto.response.VideoPresignedUrlResponse;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Video Api", description = "Video 관련 API 목록입니다.")
 public interface VideoApi {
-    @Operation(summary = "동영상의 presigned url을 발급받습니다.", description = "담당자: 최민석")
-    public Api<VideoPresignedUrlResponse> getVideoPresignedUrl(
-            @LoginMember Long memberId, @PathVariable Long videoId, @PathVariable Long groupId);
-
     @Operation(summary = "날짜를 사용한 동영상 정보 조회 발급받습니다.", description = "담당자: 최민석")
     public Api<?> searchToDate(
             @LoginMember Long memberId,

--- a/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoController.java
@@ -6,7 +6,6 @@ import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.type.VideoSuccessType;
 import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
 import org.ioteatime.meonghanyangserver.video.dto.response.VideoInfoListResponse;
-import org.ioteatime.meonghanyangserver.video.dto.response.VideoPresignedUrlResponse;
 import org.ioteatime.meonghanyangserver.video.service.VideoService;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
@@ -16,14 +15,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/video")
 public class VideoController implements VideoApi {
     private final VideoService videoService;
-
-    @GetMapping("/{videoId}/group/{groupId}")
-    public Api<VideoPresignedUrlResponse> getVideoPresignedUrl(
-            @LoginMember Long memberId, @PathVariable Long videoId, @PathVariable Long groupId) {
-        VideoPresignedUrlResponse videoPresignedUrlResponse =
-                videoService.getVideoPresignedUrl(memberId, videoId, groupId);
-        return Api.success(VideoSuccessType.GET_PRESIGNED_URL, videoPresignedUrlResponse);
-    }
 
     @GetMapping("/group/{groupId}")
     public Api<VideoInfoListResponse> searchToDate(

--- a/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoDeviceApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoDeviceApi.java
@@ -1,0 +1,15 @@
+package org.ioteatime.meonghanyangserver.video.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.ioteatime.meonghanyangserver.common.api.Api;
+import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
+import org.ioteatime.meonghanyangserver.video.dto.response.VideoPresignedUrlResponse;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "VideoDevice Api", description = "CCTV 기기에서 요청할 수 있는 Video 관련 API 목록입니다.")
+public interface VideoDeviceApi {
+    @Operation(summary = "동영상의 presigned url을 발급받습니다.", description = "담당자: 최민석")
+    Api<VideoPresignedUrlResponse> getVideoPresignedUrl(
+            @LoginMember Long memberId, @PathVariable Long videoId, @PathVariable Long groupId);
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoDeviceApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoDeviceApi.java
@@ -4,12 +4,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
+import org.ioteatime.meonghanyangserver.video.dto.request.VideoNameRequest;
 import org.ioteatime.meonghanyangserver.video.dto.response.VideoPresignedUrlResponse;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "VideoDevice Api", description = "CCTV 기기에서 요청할 수 있는 Video 관련 API 목록입니다.")
 public interface VideoDeviceApi {
-    @Operation(summary = "동영상의 presigned url을 발급받습니다.", description = "담당자: 최민석")
-    Api<VideoPresignedUrlResponse> getVideoPresignedUrl(
-            @LoginMember Long memberId, @PathVariable Long videoId, @PathVariable Long groupId);
+    @Operation(summary = "동영상 저장을 위한 presigned url을 발급받습니다.", description = "담당자: 최민석")
+    Api<VideoPresignedUrlResponse> getVideoPresignedUrlForUpload(
+            @LoginMember Long cctvId, @RequestBody VideoNameRequest videoNameRequest);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoDeviceController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoDeviceController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.type.VideoSuccessType;
 import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
+import org.ioteatime.meonghanyangserver.video.dto.request.VideoNameRequest;
 import org.ioteatime.meonghanyangserver.video.dto.response.VideoPresignedUrlResponse;
 import org.ioteatime.meonghanyangserver.video.service.VideoService;
 import org.springframework.web.bind.annotation.*;
@@ -14,11 +15,11 @@ import org.springframework.web.bind.annotation.*;
 public class VideoDeviceController implements VideoDeviceApi {
     private final VideoService videoService;
 
-    @GetMapping("/{videoId}/group/{groupId}")
-    public Api<VideoPresignedUrlResponse> getVideoPresignedUrl(
-            @LoginMember Long memberId, @PathVariable Long videoId, @PathVariable Long groupId) {
+    @PostMapping("/presigned-url")
+    public Api<VideoPresignedUrlResponse> getVideoPresignedUrlForUpload(
+            @LoginMember Long cctvId, @RequestBody VideoNameRequest videoNameRequest) {
         VideoPresignedUrlResponse videoPresignedUrlResponse =
-                videoService.getVideoPresignedUrl(memberId, videoId, groupId);
-        return Api.success(VideoSuccessType.GET_PRESIGNED_URL, videoPresignedUrlResponse);
+                videoService.generateVideoPresignedUrl(cctvId, videoNameRequest.videoName());
+        return Api.success(VideoSuccessType.GENERATE_PRESIGNED_URL, videoPresignedUrlResponse);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoDeviceController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/video/controller/VideoDeviceController.java
@@ -1,0 +1,24 @@
+package org.ioteatime.meonghanyangserver.video.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.ioteatime.meonghanyangserver.common.api.Api;
+import org.ioteatime.meonghanyangserver.common.type.VideoSuccessType;
+import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
+import org.ioteatime.meonghanyangserver.video.dto.response.VideoPresignedUrlResponse;
+import org.ioteatime.meonghanyangserver.video.service.VideoService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/video-device")
+public class VideoDeviceController implements VideoDeviceApi {
+    private final VideoService videoService;
+
+    @GetMapping("/{videoId}/group/{groupId}")
+    public Api<VideoPresignedUrlResponse> getVideoPresignedUrl(
+            @LoginMember Long memberId, @PathVariable Long videoId, @PathVariable Long groupId) {
+        VideoPresignedUrlResponse videoPresignedUrlResponse =
+                videoService.getVideoPresignedUrl(memberId, videoId, groupId);
+        return Api.success(VideoSuccessType.GET_PRESIGNED_URL, videoPresignedUrlResponse);
+    }
+}

--- a/src/main/java/org/ioteatime/meonghanyangserver/video/dto/request/VideoNameRequest.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/video/dto/request/VideoNameRequest.java
@@ -1,0 +1,8 @@
+package org.ioteatime.meonghanyangserver.video.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "동영상 이름 요청")
+public record VideoNameRequest(
+        @NotNull @Schema(description = "동영상 이름", example = "test-video.mp4") String videoName) {}

--- a/src/main/resources/application-key.yaml
+++ b/src/main/resources/application-key.yaml
@@ -3,6 +3,7 @@
 token:
   expiration-time: 86400000
   secret: ${JWT_SECRET}
+  cctv-secret: ${JWT_CCTV_SECRET}
 
 google:
   official-gmail: ${OFFICIAL_GMAIL}


### PR DESCRIPTION
### 📋 상세 설명
- CCTV도 AccessToken을 가지도록 구현하였습니다.
- CCTV가 QR 촬영 -> CCTV 생성 API 호출 -> 응답에 AccessToken 제공 -> CCTV 기기에 AccessToken 저장으로 진행됩니다.
- CCTV는 `/api/video-device`, `/api/cctv-device`, `/api/image-device`에 접근할 수 있으며, 회원은 해당 경로에 접근이 불가능합니다.
- 이 중 `HttpMethod.POST, "/api/cctv-device"`는 Token 없이도 접근이 가능합니다. (회원 가입과 동일하다고 생각하시면 됩니다.)
- <mark>미디어 파일 업로드 Presigned URL 발급 메서드를 전면 수정하였습니다. 다시 보니 GET 방식으로 하셨더라고요!</mark>

### 📸 스크린샷
<img width="838" alt="Screenshot 2024-12-04 at 17 35 08" src="https://github.com/user-attachments/assets/a75e42bc-4bd7-43b0-986a-4c3e11c5c863">
<img width="836" alt="Screenshot 2024-12-04 at 17 35 53" src="https://github.com/user-attachments/assets/f113259d-5628-4310-96ee-c3f8f6e209bf">
<img width="838" alt="Screenshot 2024-12-04 at 17 37 14" src="https://github.com/user-attachments/assets/ae173b87-c8a0-42c8-998b-dc3382e4e854">
<img width="845" alt="Screenshot 2024-12-04 at 18 06 02" src="https://github.com/user-attachments/assets/b3ec936c-ab07-4de5-912b-b72ba2347b5a">