### PR TITLE
feat: S3 이미지 저장 성공 후 DB에 저장 구현

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/ImageSuccessType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/ImageSuccessType.java
@@ -1,7 +1,7 @@
 package org.ioteatime.meonghanyangserver.common.type;
 
 public enum ImageSuccessType implements SuccessTypeCode {
-    SUCCESS_UPLOAD_IMAGE(201, "OK", "이미지 저장에 성공하였습니다."),
+    SUCCESS_UPLOAD_IMAGE(201, "CREATE", "이미지 저장에 성공하였습니다."),
     GET_LIST_OF_DATE(200, "OK", "날짜에 해당하는 이미지 목록 조회에 성공하였습니다."),
     CREATE_PRESIGNED_URL(200, "OK", "Presigned Url 생성에 성공하였습니다.");
 

--- a/src/main/java/org/ioteatime/meonghanyangserver/common/type/ImageSuccessType.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/common/type/ImageSuccessType.java
@@ -1,6 +1,7 @@
 package org.ioteatime.meonghanyangserver.common.type;
 
 public enum ImageSuccessType implements SuccessTypeCode {
+    SUCCESS_UPLOAD_IMAGE(201, "OK", "이미지 저장에 성공하였습니다."),
     GET_LIST_OF_DATE(200, "OK", "날짜에 해당하는 이미지 목록 조회에 성공하였습니다."),
     CREATE_PRESIGNED_URL(200, "OK", "Presigned Url 생성에 성공하였습니다.");
 

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/controller/ImageDeviceApi.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/controller/ImageDeviceApi.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
+import org.ioteatime.meonghanyangserver.image.dto.request.FinishUploadRequest;
 import org.ioteatime.meonghanyangserver.image.dto.request.ImageNameRequest;
 import org.ioteatime.meonghanyangserver.image.dto.response.ImageSaveUrlResponse;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,4 +17,11 @@ public interface ImageDeviceApi {
                     "담당자: 임지인\n\n캡쳐 이미지 저장을 위한 URL 발급 요청입니다.\n\nCCTV의 Access Token과 함께 요청 하시면 됩니다.")
     Api<ImageSaveUrlResponse> getImageSaveUrl(
             @LoginMember Long cctvId, @RequestBody ImageNameRequest imageNameRequest);
+
+    @Operation(
+            summary = "이미지 저장에 성공시에 DB에 저장합니다",
+            description =
+                    "담당자: 임지인\n\n이미지 저장 후 API를 호출하여 DB에 반영합니다.\n\n 이미지 이름과 함께 URL에서 경로를 추출하고 요청 하시면 됩니다.")
+    Api<Object> imageSaveSuccess(
+            @LoginMember Long cctvId, @RequestBody FinishUploadRequest finishUploadRequest);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/controller/ImageDeviceController.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/controller/ImageDeviceController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.ioteatime.meonghanyangserver.common.api.Api;
 import org.ioteatime.meonghanyangserver.common.type.ImageSuccessType;
 import org.ioteatime.meonghanyangserver.common.utils.LoginMember;
+import org.ioteatime.meonghanyangserver.image.dto.request.FinishUploadRequest;
 import org.ioteatime.meonghanyangserver.image.dto.request.ImageNameRequest;
 import org.ioteatime.meonghanyangserver.image.dto.response.ImageSaveUrlResponse;
 import org.ioteatime.meonghanyangserver.image.service.ImageService;
@@ -21,5 +22,12 @@ public class ImageDeviceController implements ImageDeviceApi {
         ImageSaveUrlResponse imageSaveUrlResponse =
                 imageService.getImageSaveUrl(cctvId, imageNameRequest.imageName());
         return Api.success(ImageSuccessType.CREATE_PRESIGNED_URL, imageSaveUrlResponse);
+    }
+
+    @PostMapping("/complete-upload")
+    public Api<Object> imageSaveSuccess(
+            @LoginMember Long cctvId, @RequestBody FinishUploadRequest finishUploadRequest) {
+        imageService.saveImage(cctvId, finishUploadRequest);
+        return Api.success((ImageSuccessType.SUCCESS_UPLOAD_IMAGE));
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/domain/ImageEntity.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/domain/ImageEntity.java
@@ -2,6 +2,7 @@ package org.ioteatime.meonghanyangserver.image.domain;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import lombok.Builder;
 import lombok.Getter;
 import org.ioteatime.meonghanyangserver.group.domain.GroupEntity;
 import org.springframework.data.annotation.CreatedDate;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @Entity
+@Builder
 @Table(name = "image")
 @EntityListeners(AuditingEntityListener.class)
 public class ImageEntity {

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/dto/request/FinishUploadRequest.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/dto/request/FinishUploadRequest.java
@@ -1,0 +1,10 @@
+package org.ioteatime.meonghanyangserver.image.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "S3 업로드 성공 응답 요청")
+public record FinishUploadRequest(
+        @NotNull @Schema(description = "이미지 이름", example = "test-image.jpg") String imageName,
+        @NotNull @Schema(description = "파일 경로", example = "img/Mhn_capture_61733381438603.jpg")
+                String imagePath) {}

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/repository/ImageRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/repository/ImageRepository.java
@@ -2,8 +2,11 @@ package org.ioteatime.meonghanyangserver.image.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.ioteatime.meonghanyangserver.image.domain.ImageEntity;
 import org.ioteatime.meonghanyangserver.image.dto.response.ImageResponse;
 
 public interface ImageRepository {
     List<ImageResponse> findAllByGroupIdAndDate(Long groupId, LocalDateTime searchDate);
+
+    ImageEntity save(ImageEntity imageEntity);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/repository/ImageRepositoryImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/repository/ImageRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.ioteatime.meonghanyangserver.image.domain.ImageEntity;
 import org.ioteatime.meonghanyangserver.image.dto.response.ImageResponse;
 import org.springframework.stereotype.Repository;
 
@@ -46,5 +47,10 @@ public class ImageRepositoryImpl implements ImageRepository {
                                                 .eq(searchDate.getDayOfMonth())))
                 .orderBy(imageEntity.createdAt.desc())
                 .fetch();
+    }
+
+    @Override
+    public ImageEntity save(ImageEntity imageEntity) {
+        return imageJpaRepository.save(imageEntity);
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/service/ImageService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/service/ImageService.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.Calendar;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.ioteatime.meonghanyangserver.cctv.domain.CctvEntity;
 import org.ioteatime.meonghanyangserver.cctv.repository.CctvRepository;
 import org.ioteatime.meonghanyangserver.clients.s3.S3Client;
 import org.ioteatime.meonghanyangserver.common.exception.BadRequestException;
@@ -14,6 +15,8 @@ import org.ioteatime.meonghanyangserver.common.type.GroupErrorType;
 import org.ioteatime.meonghanyangserver.common.type.ImageErrorType;
 import org.ioteatime.meonghanyangserver.group.domain.GroupEntity;
 import org.ioteatime.meonghanyangserver.groupmember.repository.GroupMemberRepository;
+import org.ioteatime.meonghanyangserver.image.domain.ImageEntity;
+import org.ioteatime.meonghanyangserver.image.dto.request.FinishUploadRequest;
 import org.ioteatime.meonghanyangserver.image.dto.response.GroupDateImageResponse;
 import org.ioteatime.meonghanyangserver.image.dto.response.ImageResponse;
 import org.ioteatime.meonghanyangserver.image.dto.response.ImageSaveUrlResponse;
@@ -47,6 +50,20 @@ public class ImageService {
         String presignedUrl =
                 s3Client.generatePreSignUrl(fileName, HttpMethod.PUT, Calendar.MINUTE, 10);
         return ImageResponseMapper.form(presignedUrl);
+    }
+
+    public void saveImage(Long cctvId, FinishUploadRequest finishUploadRequest) {
+        CctvEntity cctv =
+                cctvRepository
+                        .findById(cctvId)
+                        .orElseThrow(() -> new NotFoundException(CctvErrorType.NOT_FOUND));
+
+        imageRepository.save(
+                ImageEntity.builder()
+                        .imageName(finishUploadRequest.imageName())
+                        .imagePath(finishUploadRequest.imagePath())
+                        .group(cctv.getGroup())
+                        .build());
     }
 
     public GroupDateImageResponse findAllByMemberIdAndDate(


### PR DESCRIPTION
### 📋 상세 설명
- S3에서 성공 응답을 받았을 때, 호출하는 API 입니다.
- 현재는 presigned url에서 imagePath를 추출하여 imageName과 함께 api 호출 해야합니다.

### 📸 스크린샷
![01이미지저장성공](https://github.com/user-attachments/assets/1f1d6d27-7e4c-42da-9b98-2acd20b36e59)
![01이미지조회성공](https://github.com/user-attachments/assets/f07cc64f-a781-444e-9947-c4a38f35dbc6)
![01DB반영확인](https://github.com/user-attachments/assets/ef92e634-1fa0-4a00-b424-00a7bc2a85c7)