### PR TITLE
fix: AWS IoT MQTT 와일드카드 표기 수정

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/clients/iot/AIDetectClient.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/clients/iot/AIDetectClient.java
@@ -26,6 +26,7 @@ public class AIDetectClient {
         this.cctvRepository = cctvRepository;
 
         iotMqttClient.subscribe("/mhn/event/detect/things/#", this::detectEventHandler);
+        iotMqttClient.subscribe("/mhn/event/detect/things/*", this::detectEventHandler);
         log.info("[객체 탐지] {}", "탐지 Topic을 구독하였습니다.");
     }
 


### PR DESCRIPTION
### 📋 상세 설명
- AWS IoT MQTT는 와일드카드를 *과 ?를 쓰는 것 같습니다.. 배포했을 때 테스트 해보고 곧바로 적용되는 게 맞는지 확인해야 할 것 같아요.

### 📚 자료
- [문서](https://docs.aws.amazon.com/ko_kr/iot/latest/developerguide/pub-sub-policy.html#pub-sub-policy-cert)