### PR TITLE
feat: 삭제될 이미지 관리 로직 변경

### DIFF
--- a/src/main/java/org/ioteatime/meonghanyangserver/batch/job/image/ImageDeleteJobExecutionListener.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/batch/job/image/ImageDeleteJobExecutionListener.java
@@ -15,7 +15,7 @@ public class ImageDeleteJobExecutionListener implements JobExecutionListener {
     public void beforeJob(JobExecution jobExecution) {
         LocalDateTime now = LocalDateTime.now();
         log.info(
-                "[{}] - 14일이 지난 이미지 삭제 배치 작업을 시작합니다.",
+                "[{}] - 14일이 지났거나 연결된 그룹이 없는 이미지 삭제 배치 작업을 시작합니다.",
                 now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
     }
 

--- a/src/main/java/org/ioteatime/meonghanyangserver/batch/job/image/ImageItemReader.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/batch/job/image/ImageItemReader.java
@@ -34,7 +34,7 @@ public class ImageItemReader implements ItemReader<ImageEntity> {
         LocalDateTime twoWeeksAgo = LocalDateTime.now().minusDays(14);
         TypedQuery<ImageEntity> query =
                 em.createQuery(
-                                "SELECT v FROM ImageEntity v WHERE v.createdAt <= (:twoWeeksAgo)",
+                                "SELECT v FROM ImageEntity v WHERE v.createdAt <= (:twoWeeksAgo) OR v.group IS NULL",
                                 ImageEntity.class)
                         .setParameter("twoWeeksAgo", twoWeeksAgo)
                         .setFirstResult(curIdx)

--- a/src/main/java/org/ioteatime/meonghanyangserver/batch/job/image/OldImageDeleteJobConfig.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/batch/job/image/OldImageDeleteJobConfig.java
@@ -23,8 +23,8 @@ public class OldImageDeleteJobConfig {
 
     @Bean
     @JobScope
-    public Step oldImageDeleteStep(JobRepository jobRepository) {
-        return new StepBuilder("oldImageDeleteStep", jobRepository)
+    public Step oldOrRemovedImageDeleteStep(JobRepository jobRepository) {
+        return new StepBuilder("oldOrRemovedImageDeleteStep", jobRepository)
                 .<ImageEntity, ImageEntity>chunk(10, transactionManager)
                 .reader(itemReader)
                 .processor(itemProcessor)
@@ -34,10 +34,10 @@ public class OldImageDeleteJobConfig {
     }
 
     @Bean
-    public Job oldImageDeleteJob(JobRepository jobRepository) {
-        return new JobBuilder("oldImageDeleteJob", jobRepository)
+    public Job oldOrRemovedImageDeleteJob(JobRepository jobRepository) {
+        return new JobBuilder("oldOrRemovedImageDeleteJob", jobRepository)
                 .listener(imageDeleteJobExecutionListener)
-                .start(oldImageDeleteStep(jobRepository))
+                .start(oldOrRemovedImageDeleteStep(jobRepository))
                 .build();
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/batch/scheduler/BatchScheduler.java
@@ -38,7 +38,8 @@ public class BatchScheduler {
                     oldMediaDeleteJobConfig.oldMediaDeleteJob(jobRepository), jobParameters);
 
             jobLauncher.run(
-                    oldImageDeleteJobConfig.oldImageDeleteJob(jobRepository), jobParameters);
+                    oldImageDeleteJobConfig.oldOrRemovedImageDeleteJob(jobRepository),
+                    jobParameters);
 
         } catch (JobExecutionAlreadyRunningException
                 | JobInstanceAlreadyCompleteException

--- a/src/main/java/org/ioteatime/meonghanyangserver/groupmember/service/GroupMemberService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/groupmember/service/GroupMemberService.java
@@ -130,7 +130,7 @@ public class GroupMemberService {
             // 방장 퇴장
             groupMemberRepository.deleteByGroupId(groupId);
             cctvRepository.deleteByGroupId(groupId);
-            imageRepository.deleteByGroupId(groupId);
+            imageRepository.updateGroupNull(groupId);
             groupRepository.deleteById(groupId);
         } else {
             // 참여자 퇴장

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/domain/ImageEntity.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/domain/ImageEntity.java
@@ -23,7 +23,7 @@ public class ImageEntity {
     @Column(nullable = false, length = 50)
     private String imageName;
 
-    @JoinColumn(nullable = false)
+    @JoinColumn
     @ManyToOne(fetch = FetchType.LAZY)
     private GroupEntity group;
 
@@ -35,10 +35,11 @@ public class ImageEntity {
     private LocalDateTime createdAt;
 
     @Builder
-    public ImageEntity(String imageName, GroupEntity group, String imagePath) {
-
+    public ImageEntity(
+            String imageName, GroupEntity group, String imagePath, LocalDateTime createdAt) {
         this.imageName = imageName;
         this.group = group;
         this.imagePath = imagePath;
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/repository/ImageRepository.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/repository/ImageRepository.java
@@ -11,4 +11,6 @@ public interface ImageRepository {
     ImageEntity save(ImageEntity imageEntity);
 
     void deleteByGroupId(Long groupId);
+
+    void updateGroupNull(Long groupId);
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/image/repository/ImageRepositoryImpl.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/image/repository/ImageRepositoryImpl.java
@@ -58,4 +58,13 @@ public class ImageRepositoryImpl implements ImageRepository {
     public void deleteByGroupId(Long groupId) {
         imageJpaRepository.deleteByGroupId(groupId);
     }
+
+    @Override
+    public void updateGroupNull(Long groupId) {
+        queryFactory
+                .update(imageEntity)
+                .setNull(imageEntity.group)
+                .where(imageEntity.group.id.eq(groupId))
+                .execute();
+    }
 }

--- a/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
+++ b/src/main/java/org/ioteatime/meonghanyangserver/member/service/MemberService.java
@@ -116,9 +116,9 @@ public class MemberService {
             cctvRepository.deleteByGroupId(groupId);
             log.info("[방장 회원 탈퇴] {}", "GroupId 기준으로 CCTV 목록을 삭제하였습니다.");
 
-            // Image 목록 삭제
-            imageRepository.deleteByGroupId(groupId);
-            log.info("[방장 회원 탈퇴] {}", "GroupId 기준으로 Image 목록을 삭제하였습니다.");
+            // Image 목록 group 필드 null
+            imageRepository.updateGroupNull(groupId);
+            log.info("[방장 회원 탈퇴] {}", "GroupId 기준으로 Image 목록의 Group 필드를 Null로 변경하였습니다.");
 
             // GroupId 기준으로 groupMember 모두 찾아 삭제
             groupMemberRepository.deleteAllByGroupId(groupId);


### PR DESCRIPTION
### 📋 상세 설명
- 이미지를 바로 삭제해 버리면 S3에서 삭제된 이미지가 계속 남아있게 됩니다.
- 한 달 한 번 있는 배치 작업에서 특정 이미지는 실제로 DB에서 삭제가 되었는데 **저장 기한이 지나지 않았기 때문에** 남아있게 되는 문제가 있습니다.
- 이미지는 바로 삭제하지 말고, groupId를 null로 만든 뒤 배치 작업에서 groupId가 null인 객체를 S3에서 함께 삭제하는 로직으로 변경합니다.
- 기존 이미지 삭제 배치 작업에 `OR v.groupId IS NULL` 구문을 추가하여 함께 삭제 처리 되도록 구현하였습니다.

### 📸 스크린샷
- 이미지가 두 장 있습니다.
<img width="849" alt="Screenshot 2024-12-11 at 20 57 32" src="https://github.com/user-attachments/assets/5a0aba9e-614d-4174-bdcb-e0c4bcea11a0">
<img width="538" alt="Screenshot 2024-12-11 at 20 57 49" src="https://github.com/user-attachments/assets/b47b9baf-1207-47b3-ba72-0eee76008288">

- 방장 회원 탈퇴에 성공하였습니다.
<img width="628" alt="Screenshot 2024-12-11 at 20 58 36" src="https://github.com/user-attachments/assets/b950c97e-35fb-4602-ad21-a78527d418cb">

- 이미지는 groupId가 null로 설정됩니다.
<img width="540" alt="Screenshot 2024-12-11 at 20 58 47" src="https://github.com/user-attachments/assets/0935e228-aafa-48e3-9882-76d3f03ae054">

- 아직 S3에는 남아 있습니다.
<img width="1062" alt="Screenshot 2024-12-11 at 21 13 06" src="https://github.com/user-attachments/assets/f59a2db8-13ca-4c4b-897c-5fa983168c7e">

- 배치 작업이 수행됩니다. (테스트를 위해 서버 실행 시 함께 실행 되도록 설정)
<img width="1242" alt="Screenshot 2024-12-11 at 21 13 32" src="https://github.com/user-attachments/assets/4bd4708c-5092-423c-addd-cb5a40779208">

- 이미지가 삭제되었습니다.
<img width="307" alt="Screenshot 2024-12-11 at 21 13 25" src="https://github.com/user-attachments/assets/13ea33c2-a260-49e3-9581-ba0ff24d1224">
<img width="1056" alt="Screenshot 2024-12-11 at 21 13 45" src="https://github.com/user-attachments/assets/51d34e82-8168-4fed-a7e0-055b36e00885">